### PR TITLE
Kakao OAuth2.0 로그인, 회원가입 구현 (리팩토링 예정 / 로그아웃 추가, JSESSIONID HttpOnly 처리 등)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/emotionmusicnote/config/BeanConfig.java
+++ b/src/main/java/com/emotionmusicnote/config/BeanConfig.java
@@ -1,0 +1,15 @@
+package com.emotionmusicnote.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class BeanConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+
+}

--- a/src/main/java/com/emotionmusicnote/user/controller/UserLoginApiController.java
+++ b/src/main/java/com/emotionmusicnote/user/controller/UserLoginApiController.java
@@ -1,8 +1,8 @@
 package com.emotionmusicnote.user.controller;
 
 import com.emotionmusicnote.user.oauth.KakaoTokens;
-import com.emotionmusicnote.user.oauth.KakaoUserInfo;
 import com.emotionmusicnote.user.service.UserLoginService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,12 +18,12 @@ public class UserLoginApiController {
   // callback URI 을 통해 code 를 받아 token URI 로 token 을 요청한다.
   // Service 단에서 처리하도록 리팩토링 예정
   // 프론트 개발 시작하면서 code 는 프론트에서 전달하는 방식으로 바꿔야한다.
+  // 클라이언트에 저장할 수 있도록 토큰 전달
   @GetMapping("/oauth/kakao")
-  public ResponseEntity<KakaoUserInfo> oauthLogin(@RequestParam String code) {
+  public ResponseEntity<KakaoTokens> oauthLogin(
+      @RequestParam String code, HttpSession session) {
+    KakaoTokens responseKakaoTokens = userLoginService.login(code, session);
 
-    KakaoTokens kakaoTokens = userLoginService.getToken(code);
-    KakaoUserInfo kakaoUserInfo = userLoginService.getUserInfo(kakaoTokens);
-
-    return ResponseEntity.ok(kakaoUserInfo);
+    return ResponseEntity.ok(responseKakaoTokens);
   }
 }

--- a/src/main/java/com/emotionmusicnote/user/controller/UserLoginApiController.java
+++ b/src/main/java/com/emotionmusicnote/user/controller/UserLoginApiController.java
@@ -1,0 +1,29 @@
+package com.emotionmusicnote.user.controller;
+
+import com.emotionmusicnote.user.oauth.KakaoTokens;
+import com.emotionmusicnote.user.oauth.KakaoUserInfo;
+import com.emotionmusicnote.user.service.UserLoginService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class UserLoginApiController {
+
+  private final UserLoginService userLoginService;
+
+  // callback URI 을 통해 code 를 받아 token URI 로 token 을 요청한다.
+  // Service 단에서 처리하도록 리팩토링 예정
+  // 프론트 개발 시작하면서 code 는 프론트에서 전달하는 방식으로 바꿔야한다.
+  @GetMapping("/oauth/kakao")
+  public ResponseEntity<KakaoUserInfo> oauthLogin(@RequestParam String code) {
+
+    KakaoTokens kakaoTokens = userLoginService.getToken(code);
+    KakaoUserInfo kakaoUserInfo = userLoginService.getUserInfo(kakaoTokens);
+
+    return ResponseEntity.ok(kakaoUserInfo);
+  }
+}

--- a/src/main/java/com/emotionmusicnote/user/controller/UserLoginController.java
+++ b/src/main/java/com/emotionmusicnote/user/controller/UserLoginController.java
@@ -1,0 +1,14 @@
+package com.emotionmusicnote.user.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class UserLoginController {
+
+  // 로그인 폼
+  @GetMapping("/login")
+  public String loginForm() {
+    return "login";
+  }
+}

--- a/src/main/java/com/emotionmusicnote/user/domain/User.java
+++ b/src/main/java/com/emotionmusicnote/user/domain/User.java
@@ -2,11 +2,14 @@ package com.emotionmusicnote.user.domain;
 
 import com.emotionmusicnote.user.oauth.OAuthProvider;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,10 +25,15 @@ public class User {
 
   private String nickname;
 
+  private String providerId;
+
+  @Enumerated(value = EnumType.STRING)
   private OAuthProvider oAuthProvider;
 
-  public User(String nickname, OAuthProvider oAuthProvider) {
+  @Builder
+  public User(String nickname, String providerId, OAuthProvider oAuthProvider) {
     this.nickname = nickname;
+    this.providerId = providerId;
     this.oAuthProvider = oAuthProvider;
   }
 }

--- a/src/main/java/com/emotionmusicnote/user/domain/User.java
+++ b/src/main/java/com/emotionmusicnote/user/domain/User.java
@@ -1,0 +1,31 @@
+package com.emotionmusicnote.user.domain;
+
+import com.emotionmusicnote.user.oauth.OAuthProvider;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String nickname;
+
+  private OAuthProvider oAuthProvider;
+
+  public User(String nickname, OAuthProvider oAuthProvider) {
+    this.nickname = nickname;
+    this.oAuthProvider = oAuthProvider;
+  }
+}

--- a/src/main/java/com/emotionmusicnote/user/domain/UserRepository.java
+++ b/src/main/java/com/emotionmusicnote/user/domain/UserRepository.java
@@ -1,7 +1,11 @@
 package com.emotionmusicnote.user.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+  Optional<User> findByProviderId(
+      @Param(value = "providerId") String providerId);
 }

--- a/src/main/java/com/emotionmusicnote/user/domain/UserRepository.java
+++ b/src/main/java/com/emotionmusicnote/user/domain/UserRepository.java
@@ -1,0 +1,7 @@
+package com.emotionmusicnote.user.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/com/emotionmusicnote/user/oauth/KakaoTokens.java
+++ b/src/main/java/com/emotionmusicnote/user/oauth/KakaoTokens.java
@@ -1,0 +1,27 @@
+package com.emotionmusicnote.user.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KakaoTokens {
+
+  // 카카오에서 보내주는 파라미터 이름과 동일하도록 @JsonProperty 설정
+  @JsonProperty("access_token")
+  private String accessToken;
+
+  @JsonProperty("token_type")
+  private String tokenType;
+
+  @JsonProperty("refresh_token")
+  private String refreshToken;
+
+  @JsonProperty("expires_in")
+  private String expiresIn;
+
+  @JsonProperty("refresh_token_expires_in")
+  private String refreshTokenExpiresIn;
+
+  @JsonProperty("scope")
+  private String scope;
+}

--- a/src/main/java/com/emotionmusicnote/user/oauth/KakaoUserInfo.java
+++ b/src/main/java/com/emotionmusicnote/user/oauth/KakaoUserInfo.java
@@ -1,0 +1,40 @@
+package com.emotionmusicnote.user.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KakaoUserInfo {
+
+  private Long id;
+
+  @JsonProperty("kakao_account")
+  private KakaoAccount kakaoAccount;
+
+  @Getter
+  @JsonIgnoreProperties(ignoreUnknown = true) // 필요없는 정보는 제외하도록 @JsonIgnoreProperties
+  static class KakaoAccount {
+    private KakaoProfile profile;
+  }
+
+  @Getter
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class KakaoProfile {
+    private String nickname;
+
+    @JsonProperty("profile_image_url")
+    private String profileImageUrl;
+
+    @JsonProperty("thumbnail_image_url")
+    private String thumbnailImageUrl;
+  }
+
+  public String getNickname() {
+    return kakaoAccount.profile.nickname;
+  }
+
+  public OAuthProvider getOAuthProvider() {
+    return OAuthProvider.KAKAO;
+  }
+}

--- a/src/main/java/com/emotionmusicnote/user/oauth/OAuthProvider.java
+++ b/src/main/java/com/emotionmusicnote/user/oauth/OAuthProvider.java
@@ -1,0 +1,5 @@
+package com.emotionmusicnote.user.oauth;
+
+public enum OAuthProvider {
+  KAKAO, NAVER
+}

--- a/src/main/java/com/emotionmusicnote/user/service/UserLoginService.java
+++ b/src/main/java/com/emotionmusicnote/user/service/UserLoginService.java
@@ -1,0 +1,76 @@
+package com.emotionmusicnote.user.service;
+
+import com.emotionmusicnote.user.domain.UserRepository;
+import com.emotionmusicnote.user.oauth.KakaoTokens;
+import com.emotionmusicnote.user.oauth.KakaoUserInfo;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class UserLoginService {
+
+  private UserRepository userRepository;
+
+  /**
+   * GET/POST https://kapi.kakao.com/v2/user/me 으로 설정한 Headers 정보를 담아 요청
+   * 사용자 정보를 가져오기 위한 Required
+   * Parameter
+   * Header
+   *  Authorization : Bearer ${ACCESS_TOKEN}
+   *  Content-type : application/x-www-form-urlencoded;charset=utf-8
+   */
+  public KakaoTokens getToken(String code) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+    body.add("grant_type", "authorization_code");
+    body.add("client_id", "fe5038ec11bee454a846309f8fb8d1ad");
+    body.add("redirect_uri", "http://localhost:8080/oauth/kakao");
+    body.add("code", code);
+
+    HttpEntity<MultiValueMap<String, String>> requestToken = new HttpEntity<>(body, headers);
+
+    // @Bean 으로 뺴면 좋을 듯
+    RestTemplate restTemplate = new RestTemplate();
+
+    KakaoTokens responseKakaoTokens = restTemplate.postForEntity(
+            "https://kauth.kakao.com/oauth/token",
+            requestToken,
+            KakaoTokens.class)
+        .getBody();
+
+    assert responseKakaoTokens != null;
+
+    return responseKakaoTokens;
+  }
+
+  /**
+   * GET/POST https://kapi.kakao.com/v2/user/me 으로 설정한 Headers 정보를 담아 요청
+   * 사용자 정보를 가져오기 위한 Required
+   * Parameter Header
+   *  Authorization : Bearer ${ACCESS_TOKEN}
+   *  Content-type : application/x-www-form-urlencoded;charset=utf-8
+   */
+  public KakaoUserInfo getUserInfo(KakaoTokens kakaoTokens) {
+    HttpHeaders userInfoHeaders = new HttpHeaders();
+    userInfoHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    userInfoHeaders.add("Authorization", "Bearer " + kakaoTokens.getAccessToken());
+
+    HttpEntity<MultiValueMap<String, String>> requestUserProfile = new HttpEntity<>(userInfoHeaders);
+
+    RestTemplate restTemplate = new RestTemplate();
+    return restTemplate.exchange(
+            "https://kapi.kakao.com/v2/user/me",
+            HttpMethod.GET,
+            requestUserProfile,
+            KakaoUserInfo.class)
+        .getBody();
+  }
+}

--- a/src/main/java/com/emotionmusicnote/user/service/UserLoginService.java
+++ b/src/main/java/com/emotionmusicnote/user/service/UserLoginService.java
@@ -1,8 +1,11 @@
 package com.emotionmusicnote.user.service;
 
+import com.emotionmusicnote.user.domain.User;
 import com.emotionmusicnote.user.domain.UserRepository;
 import com.emotionmusicnote.user.oauth.KakaoTokens;
 import com.emotionmusicnote.user.oauth.KakaoUserInfo;
+import com.emotionmusicnote.user.oauth.OAuthProvider;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -20,15 +23,49 @@ public class UserLoginService {
   private final UserRepository userRepository;
   private final RestTemplate restTemplate;
 
+  public KakaoTokens login(String code, HttpSession session) {
+    KakaoTokens kakaoTokens = getToken(code);
+    KakaoUserInfo kakaoUserInfo = getUserInfo(kakaoTokens);
+    User user = findOrCreateUser(kakaoUserInfo);
+
+    // 사용자의 고유 정보를 포함해 세션 저장
+    // TODO : JSESSIONID 를 쿠키로 넘길 때 최소한 HttpOnly 정도는 필요할 듯
+    //  JSESSIONID 는 어떻게 검증 되는지 알아봐야한다. (톰캣 세션 매니저 ?)
+    //  id, nickname 이 저장되는 의미가 있는건지 ? (세션을 가지고 올 때 사용할 것 같기도 한데)
+    //  로그아웃 구현하면서 좀 알아보자.
+    session.setAttribute("id", user.getId());
+    session.setAttribute("nickname", user.getNickname());
+
+    return kakaoTokens;
+  }
+
+  private User findOrCreateUser(KakaoUserInfo kakaoUserInfo) {
+    // 네이버 고유 식별 ID 는 문자열 타입이라 String 으로 통일을 위해 String.valueOf() 사용
+    String providerId = String.valueOf(kakaoUserInfo.getId());
+
+    // providerId 를 통해 User 를 찾고 있다면 해당 유저를 반환, 없다면 생성 후 반환
+    return userRepository.findByProviderId(providerId)
+        .orElseGet(() -> saveUser(kakaoUserInfo));
+  }
+
+  private User saveUser(KakaoUserInfo kakaoUserInfo) {
+    User user = User.builder()
+        .nickname(kakaoUserInfo.getNickname())
+        .providerId(String.valueOf(kakaoUserInfo.getId()))
+        .oAuthProvider(OAuthProvider.KAKAO)
+        .build();
+
+    return userRepository.save(user);
+  }
+
   /**
    * GET/POST https://kapi.kakao.com/v2/user/me 으로 설정한 Headers 정보를 담아 요청
    * 사용자 정보를 가져오기 위한 Required
-   * Parameter
-   * Header
-   *  Authorization : Bearer ${ACCESS_TOKEN}
-   *  Content-type : application/x-www-form-urlencoded;charset=utf-8
+   * Parameter Header
+   * Authorization : Bearer ${ACCESS_TOKEN}
+   * Content-type : application/x-www-form-urlencoded;charset=utf-8
    */
-  public KakaoTokens getToken(String code) {
+  private KakaoTokens getToken(String code) {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
@@ -52,18 +89,17 @@ public class UserLoginService {
   }
 
   /**
-   * GET/POST https://kapi.kakao.com/v2/user/me 으로 설정한 Headers 정보를 담아 요청
-   * 사용자 정보를 가져오기 위한 Required
-   * Parameter Header
-   *  Authorization : Bearer ${ACCESS_TOKEN}
-   *  Content-type : application/x-www-form-urlencoded;charset=utf-8
+   * GET/POST https://kapi.kakao.com/v2/user/me 으로 설정한 Headers 정보를 담아 요청 사용자 정보를 가져오기 위한 Required
+   * Parameter Header Authorization : Bearer ${ACCESS_TOKEN} Content-type :
+   * application/x-www-form-urlencoded;charset=utf-8
    */
-  public KakaoUserInfo getUserInfo(KakaoTokens kakaoTokens) {
+  private KakaoUserInfo getUserInfo(KakaoTokens kakaoTokens) {
     HttpHeaders userInfoHeaders = new HttpHeaders();
     userInfoHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
     userInfoHeaders.add("Authorization", "Bearer " + kakaoTokens.getAccessToken());
 
-    HttpEntity<MultiValueMap<String, String>> requestUserProfile = new HttpEntity<>(userInfoHeaders);
+    HttpEntity<MultiValueMap<String, String>> requestUserProfile = new HttpEntity<>(
+        userInfoHeaders);
 
     return restTemplate.exchange(
             "https://kapi.kakao.com/v2/user/me",

--- a/src/main/java/com/emotionmusicnote/user/service/UserLoginService.java
+++ b/src/main/java/com/emotionmusicnote/user/service/UserLoginService.java
@@ -3,6 +3,7 @@ package com.emotionmusicnote.user.service;
 import com.emotionmusicnote.user.domain.UserRepository;
 import com.emotionmusicnote.user.oauth.KakaoTokens;
 import com.emotionmusicnote.user.oauth.KakaoUserInfo;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -12,10 +13,12 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+@RequiredArgsConstructor
 @Service
 public class UserLoginService {
 
-  private UserRepository userRepository;
+  private final UserRepository userRepository;
+  private final RestTemplate restTemplate;
 
   /**
    * GET/POST https://kapi.kakao.com/v2/user/me 으로 설정한 Headers 정보를 담아 요청
@@ -36,9 +39,6 @@ public class UserLoginService {
     body.add("code", code);
 
     HttpEntity<MultiValueMap<String, String>> requestToken = new HttpEntity<>(body, headers);
-
-    // @Bean 으로 뺴면 좋을 듯
-    RestTemplate restTemplate = new RestTemplate();
 
     KakaoTokens responseKakaoTokens = restTemplate.postForEntity(
             "https://kauth.kakao.com/oauth/token",
@@ -65,7 +65,6 @@ public class UserLoginService {
 
     HttpEntity<MultiValueMap<String, String>> requestUserProfile = new HttpEntity<>(userInfoHeaders);
 
-    RestTemplate restTemplate = new RestTemplate();
     return restTemplate.exchange(
             "https://kapi.kakao.com/v2/user/me",
             HttpMethod.GET,

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title> Login Test 화면 </title>
+</head>
+<body>
+  <a href="https://kauth.kakao.com/oauth/authorize?client_id=fe5038ec11bee454a846309f8fb8d1ad&redirect_uri=http://localhost:8080/oauth/kakao&response_type=code">
+    카카오 로그인 테스트</a>
+</body>
+</html>


### PR DESCRIPTION
commit 9957e3df3d7cb970d3fa667ed59012d3e58546f0 (HEAD -> develop, origin/develop)
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Nov 30 16:32:48 2023 +0900

    :sparkles: 카카오 로그인 API 로직 수정

    - UserLoginApiController
      - oauthLogin() 메서드 수정
      - 회원가입을 추가함에 따라 userinfo 가 아닌 회원가입 후 token 을 쿠키에 담아 반환하도록 수정

    - UserLoginService
      - login(), findOrCreateUser(), saveUser() 메서드로 분리해 회원가입 진행, 회원가입 시 HttpSession 으로 Session 저장하도록 로직 추가
      - 하드코딩 된 것들 YMAL 파일에서 가져오도록 리팩토링 예정

    - UserRepository
      - 유일한 유저를 식별하기 위한 Optional 타입의 findByProviderId() 메서드 추가

commit 8de33a5e5f96538fad8bfe7faec9cbe92c53b30b
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Nov 30 15:46:20 2023 +0900

    :sparkles: User Entity 수정
    - oAuthProvider 에 @Enumerated 추가
    - 식별 가능한 각 OAuth 에서 제공하는 providerId 를 받을 수 있도록 변수 추가

commit 7e2edeb73d569748e8f7103bbcb7b63ef002aaa9
Author: ByeoungJoon Jeon <juni8453@naver.com>
commit 7e2edeb73d569748e8f7103bbcb7b63ef002aaa9
      - 하드코딩 된 것들 YMAL 파일에서 가져오도록 리팩토링 예정

    - UserRepository
      - 유일한 유저를 식별하기 위한 Optional 타입의 findByProviderId() 메서드 추가

commit 8de33a5e5f96538fad8bfe7faec9cbe92c53b30b
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Nov 30 15:46:20 2023 +0900

    :sparkles: User Entity 수정
    - oAuthProvider 에 @Enumerated 추가
    - 식별 가능한 각 OAuth 에서 제공하는 providerId 를 받을 수 있도록 변수 추가

commit 7e2edeb73d569748e8f7103bbcb7b63ef002aaa9
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Nov 29 19:55:52 2023 +0900

    :sparkles: 수동 Bean 설정 클래스 생성

    - 외부 API 호출을 위한 RestTemplate 클래스를 Bean 으로 등록

commit 5d9e6ac4f3bb224c6d73a3569b6526624923c0d7
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Nov 28 23:32:34 2023 +0900

    :sparkles: Kakao OAuth 구현

    - 사용자 조회까지 구현
    - 리팩토링 예정

commit b40d38dba1677a9bbeb76ad403360acd74e0c120
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Nov 28 23:31:35 2023 +0900

    :sparkles: User Entity, OAuthProvider Enum 클래스 추가

    - User Entity, OAuthProvider Enum 클래스 추가

commit f6119d50eeec7b51385f5cea5d0d203c9d38cea4
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Nov 28 23:29:56 2023 +0900

    :heavy_plus_sign: thymeleaf 의존 추가

    - OAuth2.0 로그인 테스트 템플릿을 위한 thymeleaf 의존 추가