### PR TITLE
12/05 3일차 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/emotionmusicnote/common/LoginInterceptor.java
+++ b/src/main/java/com/emotionmusicnote/common/LoginInterceptor.java
@@ -1,0 +1,38 @@
+package com.emotionmusicnote.common;
+
+import com.emotionmusicnote.user.domain.User;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+public class LoginInterceptor implements HandlerInterceptor {
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws Exception {
+
+    HttpSession session = request.getSession();
+    User user = (User) session.getAttribute("user");
+
+    if (user == null) {
+      response.sendRedirect("/login");
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+      ModelAndView modelAndView) throws Exception {
+    HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
+  }
+
+  @Override
+  public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+      Object handler, Exception ex) throws Exception {
+    HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+  }
+}

--- a/src/main/java/com/emotionmusicnote/common/exception/ExceptionController.java
+++ b/src/main/java/com/emotionmusicnote/common/exception/ExceptionController.java
@@ -1,0 +1,27 @@
+package com.emotionmusicnote.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionController {
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ExceptionResponse valid(MethodArgumentNotValidException exception) {
+    ExceptionResponse response = ExceptionResponse.builder()
+        .code(HttpStatus.BAD_REQUEST.value())
+        .message("잘못된 요청입니다.")
+        .build();
+
+    for (FieldError fieldError : exception.getFieldErrors()) {
+      response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
+    }
+
+    return response;
+  }
+}

--- a/src/main/java/com/emotionmusicnote/common/exception/ExceptionResponse.java
+++ b/src/main/java/com/emotionmusicnote/common/exception/ExceptionResponse.java
@@ -1,0 +1,28 @@
+package com.emotionmusicnote.common.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ExceptionResponse {
+
+  private final int code;
+  private final String message;
+  private final Map<String, String> validation;
+
+  @Builder
+  public ExceptionResponse(int code, String message, Map<String, String> validation) {
+    this.code = code;
+    this.message = message;
+    this.validation = validation != null ? validation : new HashMap<>();
+  }
+
+  public void addValidation(String filedName, String exceptionMessage) {
+    this.validation.put(filedName, exceptionMessage);
+  }
+}
+
+
+

--- a/src/main/java/com/emotionmusicnote/common/exception/GlobalException.java
+++ b/src/main/java/com/emotionmusicnote/common/exception/GlobalException.java
@@ -1,0 +1,10 @@
+package com.emotionmusicnote.common.exception;
+
+public abstract class GlobalException extends RuntimeException {
+
+  public GlobalException(String message) {
+    super(message);
+  }
+
+  public abstract int getStatusCode();
+}

--- a/src/main/java/com/emotionmusicnote/common/exception/NotFoundNoteException.java
+++ b/src/main/java/com/emotionmusicnote/common/exception/NotFoundNoteException.java
@@ -1,0 +1,17 @@
+package com.emotionmusicnote.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundNoteException extends GlobalException {
+
+  private static final String MESSAGE = "찾을 수 없는 노트입니다.";
+
+  public NotFoundNoteException() {
+    super(MESSAGE);
+  }
+
+  @Override
+  public int getStatusCode() {
+    return HttpStatus.NOT_FOUND.value();
+  }
+}

--- a/src/main/java/com/emotionmusicnote/config/WebConfig.java
+++ b/src/main/java/com/emotionmusicnote/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.emotionmusicnote.config;
+
+import com.emotionmusicnote.common.LoginInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(new LoginInterceptor())
+        .order(1)
+        .addPathPatterns("/api/**")
+        .excludePathPatterns("/", "/login", "/css/**", "/*.ico", "/error");
+  }
+}

--- a/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
@@ -4,6 +4,7 @@ import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
 import com.emotionmusicnote.note.controller.response.NoteSingleReadResponse;
 import com.emotionmusicnote.note.service.NoteService;
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +22,7 @@ public class NoteApiController {
 
   @PostMapping("/api/notes")
   public ResponseEntity<Long> save(
-      @RequestBody NoteSaveRequest request, HttpSession session) {
+      @RequestBody @Valid NoteSaveRequest request, HttpSession session) {
 
     Long saveNoteId = noteService.save(request, session);
 

--- a/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
@@ -3,6 +3,7 @@ package com.emotionmusicnote.note.controller;
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
 import com.emotionmusicnote.note.controller.response.NoteSingleReadResponse;
 import com.emotionmusicnote.note.service.NoteService;
+import jakarta.servlet.http.HttpSession;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,9 +21,9 @@ public class NoteApiController {
 
   @PostMapping("/api/notes")
   public ResponseEntity<Long> save(
-      @RequestBody NoteSaveRequest request) {
+      @RequestBody NoteSaveRequest request, HttpSession session) {
 
-    Long saveNoteId = noteService.save(request);
+    Long saveNoteId = noteService.save(request, session);
 
     URI location = URI.create("api/notes/" + saveNoteId);
 
@@ -31,9 +32,9 @@ public class NoteApiController {
 
   @GetMapping("/api/notes/{id}")
   public ResponseEntity<NoteSingleReadResponse> read(
-      @PathVariable Long id) {
+      @PathVariable Long id, HttpSession session) {
 
-    NoteSingleReadResponse response = noteService.read(id);
+    NoteSingleReadResponse response = noteService.read(id, session);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/emotionmusicnote/note/controller/request/NoteSaveRequest.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/request/NoteSaveRequest.java
@@ -3,7 +3,9 @@ package com.emotionmusicnote.note.controller.request;
 import com.emotionmusicnote.note.domain.Note;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class NoteSaveRequest {
 

--- a/src/main/java/com/emotionmusicnote/note/controller/request/NoteSaveRequest.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/request/NoteSaveRequest.java
@@ -1,6 +1,8 @@
 package com.emotionmusicnote.note.controller.request;
 
 import com.emotionmusicnote.note.domain.Note;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,8 +11,11 @@ import lombok.NoArgsConstructor;
 @Getter
 public class NoteSaveRequest {
 
+  @Size(max = 50, message = "감정은 50자를 넘길 수 없습니다.")
+  @NotBlank(message = "오늘의 감정을 적어주세요.")
   private String emotion;
 
+  @NotBlank(message = "일기 내용을 적어주세요.")
   private String content;
 
   @Builder

--- a/src/main/java/com/emotionmusicnote/note/controller/response/NoteSingleReadResponse.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/response/NoteSingleReadResponse.java
@@ -12,14 +12,16 @@ public class NoteSingleReadResponse {
   private final String content;
   private final LocalDateTime createAt;
   private final LocalDateTime modifiedAt;
+  private final NoteWriterResponse noteWriterResponse;
 
   @Builder
   public NoteSingleReadResponse(Long id, String emotion, String content, LocalDateTime createAt,
-      LocalDateTime modifiedAt) {
+      LocalDateTime modifiedAt, NoteWriterResponse noteWriterResponse) {
     this.id = id;
     this.emotion = emotion;
     this.content = content;
     this.createAt = createAt;
     this.modifiedAt = modifiedAt;
+    this.noteWriterResponse = noteWriterResponse;
   }
 }

--- a/src/main/java/com/emotionmusicnote/note/controller/response/NoteWriterResponse.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/response/NoteWriterResponse.java
@@ -1,0 +1,20 @@
+package com.emotionmusicnote.note.controller.response;
+
+import com.emotionmusicnote.user.oauth.OAuthProvider;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class NoteWriterResponse {
+
+  private final String nickname;
+  private final String profileImageUrl;
+  private final OAuthProvider provider;
+
+  @Builder
+  public NoteWriterResponse(String nickname, String profileImageUrl, OAuthProvider provider) {
+    this.nickname = nickname;
+    this.profileImageUrl = profileImageUrl;
+    this.provider = provider;
+  }
+}

--- a/src/main/java/com/emotionmusicnote/note/domain/Note.java
+++ b/src/main/java/com/emotionmusicnote/note/domain/Note.java
@@ -1,11 +1,16 @@
 package com.emotionmusicnote.note.domain;
 
 import com.emotionmusicnote.common.BaseTime;
+import com.emotionmusicnote.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,12 +28,21 @@ public class Note extends BaseTime {
   @Column(nullable = false)
   private String emotion;
 
+  @Lob
   @Column(nullable = false)
   private String content;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
 
   @Builder
   public Note(String emotion, String content) {
     this.emotion = emotion;
     this.content = content;
+  }
+
+  public void addUser(User createUser) {
+    this.user = createUser;
   }
 }

--- a/src/main/java/com/emotionmusicnote/note/domain/NoteRepository.java
+++ b/src/main/java/com/emotionmusicnote/note/domain/NoteRepository.java
@@ -1,7 +1,14 @@
 package com.emotionmusicnote.note.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
 
+  @Query("SELECT note FROM Note note JOIN FETCH note.user WHERE note.id =:noteId AND note.user.id =:userId")
+  Optional<Note> findById(
+    @Param("noteId") Long noteId,
+    @Param("userId") Long userId);
 }

--- a/src/main/java/com/emotionmusicnote/note/service/NoteService.java
+++ b/src/main/java/com/emotionmusicnote/note/service/NoteService.java
@@ -1,5 +1,6 @@
 package com.emotionmusicnote.note.service;
 
+import com.emotionmusicnote.common.exception.NotFoundNoteException;
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
 import com.emotionmusicnote.note.controller.response.NoteSingleReadResponse;
 import com.emotionmusicnote.note.controller.response.NoteWriterResponse;
@@ -37,7 +38,7 @@ public class NoteService {
     Long loginUserId = loginUser.getId();
 
     Note findNote = noteRepository.findById(noteId, loginUserId)
-        .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 노트 입니다."));
+        .orElseThrow(NotFoundNoteException::new);
 
     User findUser = findNote.getUser();
 

--- a/src/main/java/com/emotionmusicnote/note/service/NoteService.java
+++ b/src/main/java/com/emotionmusicnote/note/service/NoteService.java
@@ -2,8 +2,11 @@ package com.emotionmusicnote.note.service;
 
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
 import com.emotionmusicnote.note.controller.response.NoteSingleReadResponse;
+import com.emotionmusicnote.note.controller.response.NoteWriterResponse;
 import com.emotionmusicnote.note.domain.Note;
 import com.emotionmusicnote.note.domain.NoteRepository;
+import com.emotionmusicnote.user.domain.User;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,21 +18,34 @@ public class NoteService {
   private final NoteRepository noteRepository;
 
   @Transactional
-  public Long save(NoteSaveRequest request) {
+  public Long save(NoteSaveRequest request, HttpSession session) {
+    User loginUser = (User)session.getAttribute("user");
     String emotion = request.getEmotion();
     String content = request.getContent();
 
     Note note = request.toEntity(emotion, content);
 
     Note saveNote = noteRepository.save(note);
+    saveNote.addUser(loginUser);
 
     return saveNote.getId();
   }
 
   @Transactional(readOnly = true)
-  public NoteSingleReadResponse read(Long id) {
-    Note findNote = noteRepository.findById(id)
+  public NoteSingleReadResponse read(Long noteId, HttpSession session) {
+    User loginUser = (User) session.getAttribute("user");
+    Long loginUserId = loginUser.getId();
+
+    Note findNote = noteRepository.findById(noteId, loginUserId)
         .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 노트 입니다."));
+
+    User findUser = findNote.getUser();
+
+    NoteWriterResponse noteWriterResponse = NoteWriterResponse.builder()
+        .nickname(findUser.getNickname())
+        .profileImageUrl(findUser.getProfileImageUrl())
+        .provider(findUser.getOAuthProvider())
+        .build();
 
     return NoteSingleReadResponse.builder()
         .id(findNote.getId())
@@ -37,6 +53,7 @@ public class NoteService {
         .content(findNote.getContent())
         .createAt(findNote.getCreatedDate())
         .modifiedAt(findNote.getModifiedDate())
+        .noteWriterResponse(noteWriterResponse)
         .build();
   }
 }

--- a/src/main/java/com/emotionmusicnote/user/domain/User.java
+++ b/src/main/java/com/emotionmusicnote/user/domain/User.java
@@ -27,13 +27,16 @@ public class User {
 
   private String providerId;
 
+  private String profileImageUrl;
+
   @Enumerated(value = EnumType.STRING)
   private OAuthProvider oAuthProvider;
 
   @Builder
-  public User(String nickname, String providerId, OAuthProvider oAuthProvider) {
+  public User(String nickname, String providerId, String profileImageUrl, OAuthProvider oAuthProvider) {
     this.nickname = nickname;
     this.providerId = providerId;
+    this.profileImageUrl = profileImageUrl;
     this.oAuthProvider = oAuthProvider;
   }
 }

--- a/src/main/java/com/emotionmusicnote/user/oauth/KakaoAccount.java
+++ b/src/main/java/com/emotionmusicnote/user/oauth/KakaoAccount.java
@@ -1,0 +1,13 @@
+package com.emotionmusicnote.user.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true) // 필요없는 정보는 제외하도록 @JsonIgnoreProperties
+public class KakaoAccount {
+
+  @JsonProperty("profile")
+  private KakaoProfile kakaoProfile;
+}

--- a/src/main/java/com/emotionmusicnote/user/oauth/KakaoProfile.java
+++ b/src/main/java/com/emotionmusicnote/user/oauth/KakaoProfile.java
@@ -1,0 +1,18 @@
+package com.emotionmusicnote.user.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoProfile {
+
+  private String nickname;
+
+  @JsonProperty("profile_image_url")
+  private String profileImageUrl;
+
+  @JsonProperty("thumbnail_image_url")
+  private String thumbnailImageUrl;
+}

--- a/src/main/java/com/emotionmusicnote/user/oauth/KakaoUserInfo.java
+++ b/src/main/java/com/emotionmusicnote/user/oauth/KakaoUserInfo.java
@@ -1,6 +1,5 @@
 package com.emotionmusicnote.user.oauth;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
@@ -12,26 +11,8 @@ public class KakaoUserInfo {
   @JsonProperty("kakao_account")
   private KakaoAccount kakaoAccount;
 
-  @Getter
-  @JsonIgnoreProperties(ignoreUnknown = true) // 필요없는 정보는 제외하도록 @JsonIgnoreProperties
-  static class KakaoAccount {
-    private KakaoProfile profile;
-  }
-
-  @Getter
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  static class KakaoProfile {
-    private String nickname;
-
-    @JsonProperty("profile_image_url")
-    private String profileImageUrl;
-
-    @JsonProperty("thumbnail_image_url")
-    private String thumbnailImageUrl;
-  }
-
   public String getNickname() {
-    return kakaoAccount.profile.nickname;
+    return kakaoAccount.getKakaoProfile().getNickname();
   }
 
   public OAuthProvider getOAuthProvider() {

--- a/src/main/java/com/emotionmusicnote/user/service/UserLoginService.java
+++ b/src/main/java/com/emotionmusicnote/user/service/UserLoginService.java
@@ -73,6 +73,7 @@ public class UserLoginService {
     User user = User.builder()
         .nickname(kakaoUserInfo.getNickname())
         .providerId(String.valueOf(kakaoUserInfo.getId()))
+        .profileImageUrl(kakaoUserInfo.getKakaoAccount().getKakaoProfile().getProfileImageUrl())
         .oAuthProvider(OAuthProvider.KAKAO)
         .build();
 

--- a/src/test/java/com/emotionmusicnote/note/service/NoteServiceTest.java
+++ b/src/test/java/com/emotionmusicnote/note/service/NoteServiceTest.java
@@ -1,7 +1,9 @@
 package com.emotionmusicnote.note.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.emotionmusicnote.common.exception.NotFoundNoteException;
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
 import com.emotionmusicnote.note.controller.response.NoteSingleReadResponse;
 import com.emotionmusicnote.note.domain.NoteRepository;
@@ -10,6 +12,7 @@ import com.emotionmusicnote.user.domain.UserRepository;
 import com.emotionmusicnote.user.oauth.OAuthProvider;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +54,8 @@ class NoteServiceTest {
   }
 
   @Test
-  void saveTest() {
+  @DisplayName("현재 로그인한 유저는 노트를 저장할 수 있습니다.")
+  void 노트_저장() {
     // given
     String emotion = "슬픔";
     String content = "내용 테스트";
@@ -66,7 +70,8 @@ class NoteServiceTest {
   }
 
   @Test
-  void read() {
+  @DisplayName("노트 아이디와 현재 로그인한 유저를 통해 해당하는 노트를 단일 조회합니다.")
+  void 내_노트_단일_조회() {
     // given
     User loginUser = (User) session.getAttribute("user");
     String emotion = "슬픔";
@@ -89,4 +94,24 @@ class NoteServiceTest {
     assertThat(response.getModifiedAt()).isBefore(LocalDateTime.now());
     assertThat(response.getNoteWriterResponse().getNickname()).isEqualTo(loginUser.getNickname());
   }
+
+  @Test
+  @DisplayName("노트 아이디가 맞지 않는 경우 NotFoundNoteException 이 호출됩니다.")
+  void 내_노트_단일_조회_실패() {
+    // given
+    String emotion = "슬픔";
+    String content = "내용 테스트";
+
+    NoteSaveRequest request = NoteSaveRequest.builder()
+        .emotion(emotion)
+        .content(content)
+        .build();
+
+    Long saveNoteId = noteService.save(request, session);
+
+    // when & then
+    assertThrows(NotFoundNoteException.class,
+        () -> noteService.read(saveNoteId + 1L, session));
+  }
+
 }

--- a/src/test/java/com/emotionmusicnote/note/service/NoteServiceTest.java
+++ b/src/test/java/com/emotionmusicnote/note/service/NoteServiceTest.java
@@ -5,11 +5,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
 import com.emotionmusicnote.note.controller.response.NoteSingleReadResponse;
 import com.emotionmusicnote.note.domain.NoteRepository;
+import com.emotionmusicnote.user.domain.User;
+import com.emotionmusicnote.user.domain.UserRepository;
+import com.emotionmusicnote.user.oauth.OAuthProvider;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
 
 @SpringBootTest
 class NoteServiceTest {
@@ -20,6 +25,26 @@ class NoteServiceTest {
   @Autowired
   private NoteRepository noteRepository;
 
+  @Autowired
+  private UserRepository userRepository;
+
+  private final MockHttpSession session = new MockHttpSession();
+
+  @Order(value = 1)
+  @BeforeEach
+  void saveDummyData() {
+    User user = User.builder()
+        .nickname("dummy_nickname")
+        .providerId("dummy_providerId")
+        .profileImageUrl("dummy_profileImageUrl")
+        .oAuthProvider(OAuthProvider.KAKAO)
+        .build();
+
+    User saveUser = userRepository.save(user);
+    session.setAttribute("user", saveUser);
+  }
+
+  @Order(value = 2)
   @BeforeEach
   public void db_init() {
     noteRepository.deleteAll();
@@ -37,12 +62,13 @@ class NoteServiceTest {
         .build();
 
     // when
-    noteService.save(request);
+    noteService.save(request, session);
   }
 
   @Test
   void read() {
     // given
+    User loginUser = (User) session.getAttribute("user");
     String emotion = "슬픔";
     String content = "내용 테스트";
 
@@ -51,15 +77,16 @@ class NoteServiceTest {
         .content(content)
         .build();
 
-    Long saveNoteId = noteService.save(request);
+    Long saveNoteId = noteService.save(request, session);
 
     // when
-    NoteSingleReadResponse response = noteService.read(saveNoteId);
+    NoteSingleReadResponse response = noteService.read(saveNoteId, session);
 
     // then
     assertThat(response.getEmotion()).isEqualTo(emotion);
     assertThat(response.getContent()).isEqualTo(content);
     assertThat(response.getCreateAt()).isBefore(LocalDateTime.now());
     assertThat(response.getModifiedAt()).isBefore(LocalDateTime.now());
+    assertThat(response.getNoteWriterResponse().getNickname()).isEqualTo(loginUser.getNickname());
   }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        default_batch_fetch_size: 100
+    sql:
+      init:
+        mode: never


### PR DESCRIPTION
commit 9d1c8eb14c7a409ff780b96772a356bf2b1ca810 (HEAD -> develop, origin/develop)
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 18:00:38 2023 +0900

    :white_check_mark: NoteServiceTest 수정 및 단일 조회 실패 테스트 추가

    - 단일 조회 실패 시 NotFoundNoteException 이 호출되는지 확인
    - 각 테스트에 @DisplayName 추가

commit 5083b5a3e823a520b0aef81ffd3123c160253e94
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 17:59:28 2023 +0900

    :sparkles: GlobalException 추가

    - RunTimeException 을 상속받는 추상 예외 클래스 GlobalException 추가
    - 노트를 찾지 못했을 때 발생하는 예외인NotFoundNoteException 추가
    - read() 내부 IllegalArgumentException 에서 NotFoundNoteException 으로 예외 클래스 교체

commit 1474c1c172364289ff1db3e635330486de8b36b5
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 17:39:54 2023 +0900

    :sparkles: NoteSaveRequest 검증 로직 추가

    - NoteSaveRequest DTO 사용 Controller 로직에 @Valid 추가
    - MethodArgumentNotValidException 예외 발생 시 ExceptionController 에서 예외를 다듬어 클라이언트로 반환하도록 예외 처리 (4XX)

commit e3ded17e128458155b8fdb9c8608b785ba11a563
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 16:50:24 2023 +0900

    :white_check_mark: NoteServiceTest 수정

    - 더미 데이터로 User 를 만들고, Session 에 저장해 테스트 전 로그인 상태를 만들어주도록 수정
    - session 데이터를 적용한 테스트 코드 수정

commit 78f8438432eea16605335d43630e3d6c3d472010
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 16:48:51 2023 +0900

    :sparkles: Interceptor 추가

    - 로그인 인터셉터 추가

commit 413f98fea3a9963b5ee40930d710f9346aa6c2f1
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 16:47:34 2023 +0900

    :bug: 노트 작성 시 데이터 바인딩 예외 해결

    - NoteSaveRequest 에 기본 생성자를 붙여주지 않아 생기던 데이터 바인딩 예외 해결

commit 022d238fef93ab1cf8781eba7b622acdaaddec0b
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 16:46:38 2023 +0900

    :sparkles: 인가 로직 구현에 의한 Note API 로직 수정

    1. NoteApiController
      - 파라미터에 HttpSession 추가

    2. NoteService
      - 노트 작성
        - Session 에서 현재 로그인 된 유저를 찾아 노트 저장시 함께 저장하도록 수정
      - 단일 노트 조회
        - Session 에서 현재 로그인 된 유저를 찾아 해당 유저가 작성한 노트 + 요청으로 들어온 노트 아이디 의 조건에 맞는 노트를 찾아 반환하도록 수정
        - 노트 작성자도 함께 반환하도록 수정

    3. NoteSingleReadResponse
      - 노트 작성자도 함께 반환하도록 필드 추가

    4. NoteWriterResponse
      - 노트 작성자 반환을 위한 Response DTO

    5. NoteRepository
      - 현재 로그인 한 유저 + 노트 아이디의 조건식을 만족하는 노트를 조회하는 메서드 생성

commit fedf3e93a282d9ba4de8c4f2b0503cd5d3f3c29e
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 16:40:05 2023 +0900

    :sparkles: Note, User 연관관계 추가

    - 여러 노트는 하나의 유저를 가지므로 ManyToOne 관계 추가
    - 연관관계 메서드 addUser() 추가

commit 5bf6dea067cdd5858bbf9a33e37449ecb92a6264
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 16:38:05 2023 +0900

    :sparkles: User 프로필 사진 필드 추가

    - 프로필 사진 필드 추가 후 로그인 findOrCreateUser() 메서드 수정

commit ac0807134e0686e045c2589e5a331e552ebeb3c7
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 16:33:15 2023 +0900

    :recycle: KakaoUserInfo 클래스 분리

    - KakaoUserInfo 클래스의 static class 였던 KakaoAccount, KakaoProfile 클래스 분리

commit 7e08152003ab407c861dc6458f74a83df6459991
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 16:32:01 2023 +0900

    :heavy_plus_sign: 테스트 H2 DB 추가

    - 테스트 용 Inmemory H2 DB 의존 추가
    - 테스트 용 H2 DB 설정 파일 추가

commit 1dd5c552e3e19cfd6573bfe664bd97682d841006
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 5 14:51:05 2023 +0900

    :recycle: 로그인 Service 코드 위치 변경

    - getToken() 을 위로 위치 변경
