### PR TITLE
12/12 4 ~ 5 일차 작업

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -6,7 +6,17 @@
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-apt/5.0.0/d48657412f2b96d787bbe5ae393e33815c94b4d0/querydsl-apt-5.0.0-jakarta.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/jakarta.annotation/jakarta.annotation-api/2.1.1/48b9bda22b091b1f48b13af03fe36db3be6e1ae3/jakarta.annotation-api-2.1.1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/jakarta.persistence/jakarta.persistence-api/3.1.0/66901fa1c373c6aff65c13791cc11da72060a8d6/jakarta.persistence-api-3.1.0.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.30/f195ee86e6c896ea47a1d39defbe20eb59cd149d/lombok-1.18.30.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-codegen/5.0.0/d690e92300f528e4161307b286f76aeaf348e2fb/querydsl-codegen-5.0.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-core/5.0.0/7a469f78b7a89bae429f17766fb92687d0ab9e5b/querydsl-core-5.0.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/codegen-utils/5.0.0/ff8a2ebbc3a317715de0ce2856c2024534d18a1a/codegen-utils-5.0.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/javax.inject/javax.inject/1/6975da39a7040257bd51d21a231b76c915872d38/javax.inject-1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/io.github.classgraph/classgraph/4.8.108/1c175d4ce7a1fa67463bad731f37f1a284dab790/classgraph-4.8.108.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.mysema.commons/mysema-commons-lang/0.2.4/d09c8489d54251a6c22fbce804bdd4a070557317/mysema-commons-lang-0.2.4.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.eclipse.jdt/ecj/3.26.0/4837be609a3368a0f7e7cf0dc1bdbc7fe94993de/ecj-3.26.0.jar" />
         </processorPath>
         <module name="emotionmusicnote.main" />
       </profile>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -16,5 +16,10 @@
       <option name="name" value="MavenRepo" />
       <option name="url" value="https://repo.maven.apache.org/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,18 @@ repositories {
 	mavenCentral()
 }
 
+allprojects {
+	repositories {
+		maven { url 'https://jitpack.io' }
+	}
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'se.michaelthelin.spotify:spotify-web-api-java:8.3.4'
 
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,17 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'com.h2database:h2'
 }
@@ -39,4 +47,21 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }

--- a/src/main/java/com/emotionmusicnote/common/PageRequest.java
+++ b/src/main/java/com/emotionmusicnote/common/PageRequest.java
@@ -1,16 +1,16 @@
-package com.emotionmusicnote.note.controller.request;
+package com.emotionmusicnote.common;
 
 import lombok.Getter;
 
 @Getter
-public class NotePageRequest {
+public class PageRequest {
 
   private static final int MAX_SIZE = 2000;
 
   private final Integer page;
   private final Integer size;
 
-  public NotePageRequest(Integer page, Integer size) {
+  public PageRequest(Integer page, Integer size) {
     this.page = (page != null) ? page : 1;
     this.size = (size != null) ? size : 5;
   }

--- a/src/main/java/com/emotionmusicnote/config/BeanConfig.java
+++ b/src/main/java/com/emotionmusicnote/config/BeanConfig.java
@@ -1,5 +1,8 @@
 package com.emotionmusicnote.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -7,9 +10,17 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class BeanConfig {
 
+  @PersistenceContext
+  private EntityManager entityManager;
+
   @Bean
   public RestTemplate restTemplate() {
     return new RestTemplate();
+  }
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
   }
 
 }

--- a/src/main/java/com/emotionmusicnote/config/BeanConfig.java
+++ b/src/main/java/com/emotionmusicnote/config/BeanConfig.java
@@ -3,12 +3,20 @@ package com.emotionmusicnote.config;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+import se.michaelthelin.spotify.SpotifyApi;
 
 @Configuration
 public class BeanConfig {
+
+  @Value("${spotify.clientId}")
+  private String clientId;
+
+  @Value("${spotify.clientSecret}")
+  private String clientSecret;
 
   @PersistenceContext
   private EntityManager entityManager;
@@ -21,6 +29,14 @@ public class BeanConfig {
   @Bean
   public JPAQueryFactory jpaQueryFactory() {
     return new JPAQueryFactory(entityManager);
+  }
+
+  @Bean
+  public SpotifyApi spotifyApi() {
+    return new SpotifyApi.Builder()
+        .setClientId(clientId)
+        .setClientSecret(clientSecret)
+        .build();
   }
 
 }

--- a/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
@@ -1,6 +1,7 @@
 package com.emotionmusicnote.note.controller;
 
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
+import com.emotionmusicnote.note.controller.request.NoteUpdateRequest;
 import com.emotionmusicnote.note.controller.response.NoteSingleReadResponse;
 import com.emotionmusicnote.note.service.NoteService;
 import jakarta.servlet.http.HttpSession;
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,5 +40,13 @@ public class NoteApiController {
     NoteSingleReadResponse response = noteService.read(id, session);
 
     return ResponseEntity.ok(response);
+  }
+
+  @PutMapping("/api/notes/{id}")
+  public void update(
+      @PathVariable Long id,
+      @RequestBody @Valid NoteUpdateRequest request, HttpSession session) {
+
+    noteService.update(id, request, session);
   }
 }

--- a/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,4 +50,12 @@ public class NoteApiController {
 
     noteService.update(id, request, session);
   }
+
+  @DeleteMapping("/api/notes/{id}")
+  public void delete(
+      @PathVariable Long id, HttpSession session) {
+
+    noteService.delete(id, session);
+  }
+
 }

--- a/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
@@ -1,7 +1,9 @@
 package com.emotionmusicnote.note.controller;
 
+import com.emotionmusicnote.note.controller.request.NotePageRequest;
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
 import com.emotionmusicnote.note.controller.request.NoteUpdateRequest;
+import com.emotionmusicnote.note.controller.response.NoteMultiReadResponse;
 import com.emotionmusicnote.note.controller.response.NoteSingleReadResponse;
 import com.emotionmusicnote.note.service.NoteService;
 import jakarta.servlet.http.HttpSession;
@@ -11,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -34,15 +37,6 @@ public class NoteApiController {
     return ResponseEntity.created(location).body(saveNoteId);
   }
 
-  @GetMapping("/api/notes/{id}")
-  public ResponseEntity<NoteSingleReadResponse> read(
-      @PathVariable Long id, HttpSession session) {
-
-    NoteSingleReadResponse response = noteService.read(id, session);
-
-    return ResponseEntity.ok(response);
-  }
-
   @PutMapping("/api/notes/{id}")
   public void update(
       @PathVariable Long id,
@@ -56,6 +50,24 @@ public class NoteApiController {
       @PathVariable Long id, HttpSession session) {
 
     noteService.delete(id, session);
+  }
+
+  @GetMapping("/api/notes/{id}")
+  public ResponseEntity<NoteSingleReadResponse> read(
+      @PathVariable Long id, HttpSession session) {
+
+    NoteSingleReadResponse response = noteService.read(id, session);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/api/notes")
+  public ResponseEntity<NoteMultiReadResponse> readAll(
+      @ModelAttribute NotePageRequest notePageRequest, HttpSession session) {
+
+    NoteMultiReadResponse response = noteService.readAll(notePageRequest, session);
+
+    return ResponseEntity.ok(response);
   }
 
 }

--- a/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/NoteApiController.java
@@ -1,6 +1,6 @@
 package com.emotionmusicnote.note.controller;
 
-import com.emotionmusicnote.note.controller.request.NotePageRequest;
+import com.emotionmusicnote.common.PageRequest;
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
 import com.emotionmusicnote.note.controller.request.NoteUpdateRequest;
 import com.emotionmusicnote.note.controller.response.NoteMultiReadResponse;
@@ -63,9 +63,9 @@ public class NoteApiController {
 
   @GetMapping("/api/notes")
   public ResponseEntity<NoteMultiReadResponse> readAll(
-      @ModelAttribute NotePageRequest notePageRequest, HttpSession session) {
+      @ModelAttribute PageRequest pageRequest, HttpSession session) {
 
-    NoteMultiReadResponse response = noteService.readAll(notePageRequest, session);
+    NoteMultiReadResponse response = noteService.readAll(pageRequest, session);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/emotionmusicnote/note/controller/request/NotePageRequest.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/request/NotePageRequest.java
@@ -1,0 +1,23 @@
+package com.emotionmusicnote.note.controller.request;
+
+import lombok.Getter;
+
+@Getter
+public class NotePageRequest {
+
+  private static final int MAX_SIZE = 2000;
+
+  private final Integer page;
+  private final Integer size;
+
+  public NotePageRequest(Integer page, Integer size) {
+    this.page = (page != null) ? page : 1;
+    this.size = (size != null) ? size : 5;
+  }
+
+  // page 가 0인 경우 최소한 1을 반환하기 위함
+  // size 가 너무 커지지 않도록 조치
+  public long getOffset() {
+    return (long) (Math.max(1, page) - 1) * Math.min(MAX_SIZE, size);
+  }
+}

--- a/src/main/java/com/emotionmusicnote/note/controller/request/NoteUpdateRequest.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/request/NoteUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.emotionmusicnote.note.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class NoteUpdateRequest {
+
+  @Size(max = 50, message = "감정은 50자를 넘길 수 없습니다.")
+  @NotBlank(message = "오늘의 감정을 적어주세요.")
+  private String emotion;
+
+  @NotBlank(message = "일기 내용을 적어주세요.")
+  private String content;
+
+  @Builder
+  public NoteUpdateRequest(String emotion, String content) {
+    this.emotion = emotion;
+    this.content = content;
+  }
+}

--- a/src/main/java/com/emotionmusicnote/note/controller/response/NoteMultiReadResponse.java
+++ b/src/main/java/com/emotionmusicnote/note/controller/response/NoteMultiReadResponse.java
@@ -1,0 +1,16 @@
+package com.emotionmusicnote.note.controller.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class NoteMultiReadResponse {
+
+  private final List<NoteSingleReadResponse> notes;
+
+  @Builder
+  public NoteMultiReadResponse(List<NoteSingleReadResponse> notes) {
+    this.notes = notes;
+  }
+}

--- a/src/main/java/com/emotionmusicnote/note/domain/Note.java
+++ b/src/main/java/com/emotionmusicnote/note/domain/Note.java
@@ -45,4 +45,9 @@ public class Note extends BaseTime {
   public void addUser(User createUser) {
     this.user = createUser;
   }
+
+  public void updateNote(String emotion, String content) {
+    this.emotion = emotion;
+    this.content = content;
+  }
 }

--- a/src/main/java/com/emotionmusicnote/note/domain/NoteCustomRepository.java
+++ b/src/main/java/com/emotionmusicnote/note/domain/NoteCustomRepository.java
@@ -1,0 +1,10 @@
+package com.emotionmusicnote.note.domain;
+
+import com.emotionmusicnote.note.controller.request.NotePageRequest;
+import java.util.List;
+
+public interface NoteCustomRepository {
+
+  List<Note> findAll(Long loginUserId, NotePageRequest notePageRequest);
+
+}

--- a/src/main/java/com/emotionmusicnote/note/domain/NoteCustomRepository.java
+++ b/src/main/java/com/emotionmusicnote/note/domain/NoteCustomRepository.java
@@ -1,10 +1,10 @@
 package com.emotionmusicnote.note.domain;
 
-import com.emotionmusicnote.note.controller.request.NotePageRequest;
+import com.emotionmusicnote.common.PageRequest;
 import java.util.List;
 
 public interface NoteCustomRepository {
 
-  List<Note> findAll(Long loginUserId, NotePageRequest notePageRequest);
+  List<Note> findAll(Long loginUserId, PageRequest pageRequest);
 
 }

--- a/src/main/java/com/emotionmusicnote/note/domain/NoteRepository.java
+++ b/src/main/java/com/emotionmusicnote/note/domain/NoteRepository.java
@@ -5,10 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface NoteRepository extends JpaRepository<Note, Long> {
+public interface NoteRepository extends JpaRepository<Note, Long>, NoteCustomRepository {
 
   @Query("SELECT note FROM Note note JOIN FETCH note.user WHERE note.id =:noteId AND note.user.id =:userId")
   Optional<Note> findById(
-    @Param("noteId") Long noteId,
-    @Param("userId") Long userId);
+      @Param("noteId") Long noteId,
+      @Param("userId") Long userId);
 }

--- a/src/main/java/com/emotionmusicnote/note/domain/NoteRepositoryImpl.java
+++ b/src/main/java/com/emotionmusicnote/note/domain/NoteRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.emotionmusicnote.note.domain;
 
 import static com.emotionmusicnote.note.domain.QNote.note;
 
-import com.emotionmusicnote.note.controller.request.NotePageRequest;
+import com.emotionmusicnote.common.PageRequest;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,15 +13,15 @@ public class NoteRepositoryImpl implements NoteCustomRepository {
   private final JPAQueryFactory jpaQueryFactory;
 
   @Override
-  public List<Note> findAll(Long userLoginId, NotePageRequest notePageRequest) {
+  public List<Note> findAll(Long userLoginId, PageRequest pageRequest) {
     System.out.println("userLoginId = " + userLoginId);
 
     return jpaQueryFactory.selectFrom(note)
         .join(note.user).fetchJoin()
         .where(note.user.id.eq(userLoginId))
         .orderBy(note.id.desc())
-        .offset(notePageRequest.getOffset())
-        .limit(notePageRequest.getSize())
+        .offset(pageRequest.getOffset())
+        .limit(pageRequest.getSize())
         .fetch();
   }
 }

--- a/src/main/java/com/emotionmusicnote/note/domain/NoteRepositoryImpl.java
+++ b/src/main/java/com/emotionmusicnote/note/domain/NoteRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.emotionmusicnote.note.domain;
+
+import static com.emotionmusicnote.note.domain.QNote.note;
+
+import com.emotionmusicnote.note.controller.request.NotePageRequest;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class NoteRepositoryImpl implements NoteCustomRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public List<Note> findAll(Long userLoginId, NotePageRequest notePageRequest) {
+    System.out.println("userLoginId = " + userLoginId);
+
+    return jpaQueryFactory.selectFrom(note)
+        .join(note.user).fetchJoin()
+        .where(note.user.id.eq(userLoginId))
+        .orderBy(note.id.desc())
+        .offset(notePageRequest.getOffset())
+        .limit(notePageRequest.getSize())
+        .fetch();
+  }
+}

--- a/src/main/java/com/emotionmusicnote/note/service/NoteService.java
+++ b/src/main/java/com/emotionmusicnote/note/service/NoteService.java
@@ -72,4 +72,15 @@ public class NoteService {
 
     findNote.updateNote(emotion, content);
   }
+
+  @Transactional
+  public void delete(Long noteId, HttpSession session) {
+    User loginUser = (User) session.getAttribute("user");
+    Long loginUserId = loginUser.getId();
+
+    Note findNote = noteRepository.findById(noteId, loginUserId)
+        .orElseThrow(NotFoundNoteException::new);
+
+    noteRepository.delete(findNote);
+  }
 }

--- a/src/main/java/com/emotionmusicnote/note/service/NoteService.java
+++ b/src/main/java/com/emotionmusicnote/note/service/NoteService.java
@@ -2,6 +2,7 @@ package com.emotionmusicnote.note.service;
 
 import com.emotionmusicnote.common.exception.NotFoundNoteException;
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
+import com.emotionmusicnote.note.controller.request.NoteUpdateRequest;
 import com.emotionmusicnote.note.controller.response.NoteSingleReadResponse;
 import com.emotionmusicnote.note.controller.response.NoteWriterResponse;
 import com.emotionmusicnote.note.domain.Note;
@@ -20,7 +21,7 @@ public class NoteService {
 
   @Transactional
   public Long save(NoteSaveRequest request, HttpSession session) {
-    User loginUser = (User)session.getAttribute("user");
+    User loginUser = (User) session.getAttribute("user");
     String emotion = request.getEmotion();
     String content = request.getContent();
 
@@ -56,5 +57,19 @@ public class NoteService {
         .modifiedAt(findNote.getModifiedDate())
         .noteWriterResponse(noteWriterResponse)
         .build();
+  }
+
+  @Transactional
+  public void update(Long noteId, NoteUpdateRequest request, HttpSession session) {
+    User loginUser = (User) session.getAttribute("user");
+    Long loginUserId = loginUser.getId();
+
+    Note findNote = noteRepository.findById(noteId, loginUserId)
+        .orElseThrow(NotFoundNoteException::new);
+
+    String emotion = request.getEmotion();
+    String content = request.getContent();
+
+    findNote.updateNote(emotion, content);
   }
 }

--- a/src/main/java/com/emotionmusicnote/note/service/NoteService.java
+++ b/src/main/java/com/emotionmusicnote/note/service/NoteService.java
@@ -1,7 +1,7 @@
 package com.emotionmusicnote.note.service;
 
 import com.emotionmusicnote.common.exception.NotFoundNoteException;
-import com.emotionmusicnote.note.controller.request.NotePageRequest;
+import com.emotionmusicnote.common.PageRequest;
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
 import com.emotionmusicnote.note.controller.request.NoteUpdateRequest;
 import com.emotionmusicnote.note.controller.response.NoteMultiReadResponse;
@@ -89,11 +89,11 @@ public class NoteService {
   }
 
   @Transactional(readOnly = true)
-  public NoteMultiReadResponse readAll(NotePageRequest notePageRequest, HttpSession session) {
+  public NoteMultiReadResponse readAll(PageRequest pageRequest, HttpSession session) {
     User loginUser = (User) session.getAttribute("user");
     Long loginUserId = loginUser.getId();
 
-    List<Note> notes = noteRepository.findAll(loginUserId, notePageRequest);
+    List<Note> notes = noteRepository.findAll(loginUserId, pageRequest);
 
     List<NoteSingleReadResponse> response = notes.stream()
         .map(note -> NoteSingleReadResponse.builder()

--- a/src/main/java/com/emotionmusicnote/spotify/controller/SpotifyApiController.java
+++ b/src/main/java/com/emotionmusicnote/spotify/controller/SpotifyApiController.java
@@ -1,0 +1,42 @@
+package com.emotionmusicnote.spotify.controller;
+
+import com.emotionmusicnote.common.PageRequest;
+import com.emotionmusicnote.spotify.controller.request.SpotifySaveRequest;
+import com.emotionmusicnote.spotify.controller.response.SpotifyMultiSearchResponse;
+import com.emotionmusicnote.spotify.service.SpotifyService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class SpotifyApiController {
+
+  private final SpotifyService spotifyService;
+
+  @GetMapping("/api/songs")
+  public ResponseEntity<SpotifyMultiSearchResponse> searchSongs(
+      @RequestParam String keyword, @ModelAttribute PageRequest pageRequest) {
+
+    SpotifyMultiSearchResponse response = spotifyService.searchTracks(keyword, pageRequest);
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/api/songs/{noteId}")
+  public ResponseEntity<Long> saveSong(
+      @RequestBody SpotifySaveRequest request,
+      @PathVariable Long noteId) {
+    Long saveSongId = spotifyService.saveSongMyNote(noteId, request);
+
+    URI location = URI.create("api/songs/" + saveSongId);
+
+    return ResponseEntity.created(location).body(saveSongId);
+  }
+}

--- a/src/main/java/com/emotionmusicnote/spotify/controller/request/SpotifySaveRequest.java
+++ b/src/main/java/com/emotionmusicnote/spotify/controller/request/SpotifySaveRequest.java
@@ -1,0 +1,34 @@
+package com.emotionmusicnote.spotify.controller.request;
+
+import com.emotionmusicnote.spotify.domain.Song;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class SpotifySaveRequest {
+
+  private String artistName;
+  private String title;
+  private String albumName;
+  private String imageUrl;
+
+  @Builder
+  public SpotifySaveRequest(String artistName, String title, String albumName,
+      String imageUrl) {
+    this.artistName = artistName;
+    this.title = title;
+    this.albumName = albumName;
+    this.imageUrl = imageUrl;
+  }
+
+  public Song toEntity(String artistName, String title, String albumName, String imageUrl) {
+    return Song.builder()
+        .artistName(artistName)
+        .albumName(albumName)
+        .title(title)
+        .imageUrl(imageUrl)
+        .build();
+  }
+}

--- a/src/main/java/com/emotionmusicnote/spotify/controller/response/SpotifyMultiSearchResponse.java
+++ b/src/main/java/com/emotionmusicnote/spotify/controller/response/SpotifyMultiSearchResponse.java
@@ -1,0 +1,17 @@
+package com.emotionmusicnote.spotify.controller.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SpotifyMultiSearchResponse {
+
+  private final List<SpotifySingleSearchResponse> responses;
+
+  @Builder
+  public SpotifyMultiSearchResponse(
+      List<SpotifySingleSearchResponse> responses) {
+    this.responses = responses;
+  }
+}

--- a/src/main/java/com/emotionmusicnote/spotify/controller/response/SpotifySingleSearchResponse.java
+++ b/src/main/java/com/emotionmusicnote/spotify/controller/response/SpotifySingleSearchResponse.java
@@ -1,0 +1,22 @@
+package com.emotionmusicnote.spotify.controller.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SpotifySingleSearchResponse {
+
+  private final String artistName;
+  private final String title;
+  private final String albumName;
+  private final String imageUrl;
+
+  @Builder
+  public SpotifySingleSearchResponse(String artistName, String title, String albumName,
+      String imageUrl) {
+    this.artistName = artistName;
+    this.title = title;
+    this.albumName = albumName;
+    this.imageUrl = imageUrl;
+  }
+}

--- a/src/main/java/com/emotionmusicnote/spotify/domain/Song.java
+++ b/src/main/java/com/emotionmusicnote/spotify/domain/Song.java
@@ -1,0 +1,48 @@
+package com.emotionmusicnote.spotify.domain;
+
+import com.emotionmusicnote.note.domain.Note;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Song {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String artistName;
+
+  private String title;
+
+  private String albumName;
+
+  private String imageUrl;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "note_id")
+  private Note note;
+
+  @Builder
+  public Song(String artistName, String title, String albumName, String imageUrl) {
+    this.artistName = artistName;
+    this.title = title;
+    this.albumName = albumName;
+    this.imageUrl = imageUrl;
+  }
+
+  public void addNote(Note note) {
+    this.note = note;
+  }
+}

--- a/src/main/java/com/emotionmusicnote/spotify/domain/SongRepository.java
+++ b/src/main/java/com/emotionmusicnote/spotify/domain/SongRepository.java
@@ -1,0 +1,7 @@
+package com.emotionmusicnote.spotify.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SongRepository extends JpaRepository<Song, Long> {
+
+}

--- a/src/main/java/com/emotionmusicnote/spotify/service/CreateSpotifyToken.java
+++ b/src/main/java/com/emotionmusicnote/spotify/service/CreateSpotifyToken.java
@@ -1,24 +1,20 @@
 package com.emotionmusicnote.spotify.service;
 
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import org.apache.hc.core5.http.ParseException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import se.michaelthelin.spotify.SpotifyApi;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.credentials.ClientCredentials;
 import se.michaelthelin.spotify.requests.authorization.client_credentials.ClientCredentialsRequest;
 
+@RequiredArgsConstructor
 @Component
 public class CreateSpotifyToken {
 
-  private final String clientId = "clientId";
-
-  private final String clientSecret = "clientSecret";
-
-  private final SpotifyApi spotifyApi = new SpotifyApi.Builder()
-      .setClientId(clientId)
-      .setClientSecret(clientSecret)
-      .build();
+  private final SpotifyApi spotifyApi;
 
   public void setAccessToken() {
     ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();

--- a/src/main/java/com/emotionmusicnote/spotify/service/CreateSpotifyToken.java
+++ b/src/main/java/com/emotionmusicnote/spotify/service/CreateSpotifyToken.java
@@ -1,0 +1,38 @@
+package com.emotionmusicnote.spotify.service;
+
+import java.io.IOException;
+import org.apache.hc.core5.http.ParseException;
+import org.springframework.stereotype.Component;
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.credentials.ClientCredentials;
+import se.michaelthelin.spotify.requests.authorization.client_credentials.ClientCredentialsRequest;
+
+@Component
+public class CreateSpotifyToken {
+
+  private final String clientId = "clientId";
+
+  private final String clientSecret = "clientSecret";
+
+  private final SpotifyApi spotifyApi = new SpotifyApi.Builder()
+      .setClientId(clientId)
+      .setClientSecret(clientSecret)
+      .build();
+
+  public void setAccessToken() {
+    ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();
+
+    try {
+      ClientCredentials clientCredentials = clientCredentialsRequest.execute();
+      spotifyApi.setAccessToken(clientCredentials.getAccessToken());
+
+    } catch (IOException | SpotifyWebApiException | ParseException exception) {
+      exception.printStackTrace();
+    }
+  }
+
+  public SpotifyApi getSpotifyApi() {
+    return spotifyApi;
+  }
+}

--- a/src/main/java/com/emotionmusicnote/spotify/service/SpotifyService.java
+++ b/src/main/java/com/emotionmusicnote/spotify/service/SpotifyService.java
@@ -1,0 +1,96 @@
+package com.emotionmusicnote.spotify.service;
+
+import com.emotionmusicnote.common.PageRequest;
+import com.emotionmusicnote.common.exception.NotFoundNoteException;
+import com.emotionmusicnote.note.domain.Note;
+import com.emotionmusicnote.note.domain.NoteRepository;
+import com.emotionmusicnote.spotify.controller.request.SpotifySaveRequest;
+import com.emotionmusicnote.spotify.controller.response.SpotifyMultiSearchResponse;
+import com.emotionmusicnote.spotify.controller.response.SpotifySingleSearchResponse;
+import com.emotionmusicnote.spotify.domain.Song;
+import com.emotionmusicnote.spotify.domain.SongRepository;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.hc.core5.http.ParseException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.specification.AlbumSimplified;
+import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
+import se.michaelthelin.spotify.model_objects.specification.Image;
+import se.michaelthelin.spotify.model_objects.specification.Paging;
+import se.michaelthelin.spotify.model_objects.specification.Track;
+import se.michaelthelin.spotify.requests.data.search.simplified.SearchTracksRequest;
+
+@RequiredArgsConstructor
+@Service
+public class SpotifyService {
+
+  private final CreateSpotifyToken createSpotifyToken;
+  private final NoteRepository noteRepository;
+  private final SongRepository songRepository;
+
+  @Transactional(readOnly = true)
+  public SpotifyMultiSearchResponse searchTracks(String keyword, PageRequest pageRequest) {
+    createSpotifyToken.setAccessToken();
+    SpotifyApi spotifyApi = createSpotifyToken.getSpotifyApi();
+
+    List<SpotifySingleSearchResponse> response = new ArrayList<>();
+
+    try {
+      SearchTracksRequest searchTracksRequest = spotifyApi.searchTracks(keyword)
+          .q(keyword)
+          .limit(pageRequest.getSize())
+          .offset((int) pageRequest.getOffset())
+          .build();
+
+      Paging<Track> searchResult = searchTracksRequest.execute();
+      Track[] tracks = searchResult.getItems();
+
+      for (Track track : tracks) {
+        String title = track.getName();
+        AlbumSimplified album = track.getAlbum();
+        String albumName = album.getName();
+        ArtistSimplified[] artists = album.getArtists();
+        String artistName = artists[0].getName();
+        Image[] images = album.getImages();
+        String imageUrl = (images.length > 0) ? images[0].getUrl() : "NO_IMAGE";
+
+        response.add(SpotifySingleSearchResponse.builder()
+            .artistName(artistName)
+            .title(title)
+            .albumName(albumName)
+            .imageUrl(imageUrl)
+            .build());
+      }
+
+    } catch (IOException | SpotifyWebApiException | ParseException exception) {
+      exception.printStackTrace();
+    }
+
+    return SpotifyMultiSearchResponse.builder()
+        .responses(response)
+        .build();
+  }
+
+  @Transactional
+  public Long saveSongMyNote(Long noteId, SpotifySaveRequest request) {
+    Note findNote = noteRepository.findById(noteId)
+        .orElseThrow(NotFoundNoteException::new);
+
+    String artistName = request.getArtistName();
+    String albumName = request.getAlbumName();
+    String title = request.getTitle();
+    String imageUrl = request.getImageUrl();
+
+    Song song = request.toEntity(artistName, title, albumName, imageUrl);
+
+    Song saveSong = songRepository.save(song);
+    saveSong.addNote(findNote);
+
+    return saveSong.getId();
+  }
+}

--- a/src/test/java/com/emotionmusicnote/note/service/NoteServiceTest.java
+++ b/src/test/java/com/emotionmusicnote/note/service/NoteServiceTest.java
@@ -13,6 +13,7 @@ import com.emotionmusicnote.user.domain.User;
 import com.emotionmusicnote.user.domain.UserRepository;
 import com.emotionmusicnote.user.oauth.OAuthProvider;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
@@ -148,5 +149,29 @@ class NoteServiceTest {
     Note findNote = noteRepository.findById(saveNoteId, loginUserId).get();
     assertThat(findNote.getEmotion()).isEqualTo(updateEmotion);
     assertThat(findNote.getContent()).isEqualTo(updateContent);
+  }
+
+  @Test
+  @DisplayName("자신이 작성한 노트를 삭제할 수 있습니다.")
+  void 내_노트_삭제() {
+    // given
+    User loginUser = (User) session.getAttribute("user");
+
+    String emotion = "슬픔";
+    String content = "내용 테스트";
+
+    NoteSaveRequest saveRequest = NoteSaveRequest.builder()
+        .emotion(emotion)
+        .content(content)
+        .build();
+
+    Long saveNoteId = noteService.save(saveRequest, session);
+
+    // when
+    noteService.delete(saveNoteId, session);
+
+    // then
+    List<Note> notes = noteRepository.findAll();
+    assertThat(notes.size()).isEqualTo(0);
   }
 }

--- a/src/test/java/com/emotionmusicnote/note/service/NoteServiceTest.java
+++ b/src/test/java/com/emotionmusicnote/note/service/NoteServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.emotionmusicnote.common.exception.NotFoundNoteException;
-import com.emotionmusicnote.note.controller.request.NotePageRequest;
+import com.emotionmusicnote.common.PageRequest;
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
 import com.emotionmusicnote.note.controller.request.NoteUpdateRequest;
 import com.emotionmusicnote.note.controller.response.NoteMultiReadResponse;
@@ -16,7 +16,6 @@ import com.emotionmusicnote.user.domain.UserRepository;
 import com.emotionmusicnote.user.oauth.OAuthProvider;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -193,10 +192,10 @@ class NoteServiceTest {
       noteService.save(request, session);
     }
 
-    NotePageRequest notePageRequest = new NotePageRequest(null, null);
+    PageRequest pageRequest = new PageRequest(null, null);
 
     // when
-    NoteMultiReadResponse noteMultiReadResponse = noteService.readAll(notePageRequest, session);
+    NoteMultiReadResponse noteMultiReadResponse = noteService.readAll(pageRequest, session);
 
     // then
     assertThat(noteMultiReadResponse.getNotes().size()).isEqualTo(5);
@@ -216,10 +215,10 @@ class NoteServiceTest {
       noteService.save(request, session);
     }
 
-    NotePageRequest notePageRequest = new NotePageRequest(2, null);
+    PageRequest pageRequest = new PageRequest(2, null);
 
     // when
-    NoteMultiReadResponse noteMultiReadResponse = noteService.readAll(notePageRequest, session);
+    NoteMultiReadResponse noteMultiReadResponse = noteService.readAll(pageRequest, session);
     assertThat(noteMultiReadResponse.getNotes().get(0).getEmotion()).isEqualTo("emotion - 5");
   }
 }

--- a/src/test/java/com/emotionmusicnote/note/service/NoteServiceTest.java
+++ b/src/test/java/com/emotionmusicnote/note/service/NoteServiceTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.emotionmusicnote.common.exception.NotFoundNoteException;
 import com.emotionmusicnote.note.controller.request.NoteSaveRequest;
+import com.emotionmusicnote.note.controller.request.NoteUpdateRequest;
 import com.emotionmusicnote.note.controller.response.NoteSingleReadResponse;
+import com.emotionmusicnote.note.domain.Note;
 import com.emotionmusicnote.note.domain.NoteRepository;
 import com.emotionmusicnote.user.domain.User;
 import com.emotionmusicnote.user.domain.UserRepository;
@@ -114,4 +116,37 @@ class NoteServiceTest {
         () -> noteService.read(saveNoteId + 1L, session));
   }
 
+  @Test
+  @DisplayName("자신이 작성한 노트를 수정할 수 있습니다.")
+  void 내_노트_수정() {
+    // given
+    User loginUser = (User) session.getAttribute("user");
+    Long loginUserId = loginUser.getId();
+
+    String emotion = "슬픔";
+    String content = "내용";
+
+    NoteSaveRequest saveRequest = NoteSaveRequest.builder()
+        .emotion(emotion)
+        .content(content)
+        .build();
+
+    Long saveNoteId = noteService.save(saveRequest, session);
+
+    String updateEmotion = "기쁨";
+    String updateContent = "수정 내용";
+
+    NoteUpdateRequest updateRequest = NoteUpdateRequest.builder()
+        .emotion(updateEmotion)
+        .content(updateContent)
+        .build();
+
+    // when
+    noteService.update(saveNoteId, updateRequest, session);
+
+    // then
+    Note findNote = noteRepository.findById(saveNoteId, loginUserId).get();
+    assertThat(findNote.getEmotion()).isEqualTo(updateEmotion);
+    assertThat(findNote.getContent()).isEqualTo(updateContent);
+  }
 }


### PR DESCRIPTION
commit c7cdba629ca7ffcd094a390b7fab14afefd39043 (HEAD -> develop, origin/develop)
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 12 13:00:00 2023 +0900

    :recycle: SpotifyApi Bean 객체 등록

    - BeanConfig 에 SpotifyApi 의 ClientId, ClientSecret 을 @Value 를 통해 가지고 온 값으로 SpotifyApi 를 생성 후 Bean 객체로 등록하여 사용하도록 변경

commit c1241a84f34b2f460d86e5896b134fd40493bf76
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 12 12:52:27 2023 +0900

    :sparkles: Spotify Search API 연동

    1. SpotifyApiController
      - searchSongs() : 노래 검색 담당
      - saveSong() : 노트에 노래 저장 담당

    2. SpotifyService

    3. CreateSpotifyToken

    4. Request, Response DTO
      - SpotifySaveRequest
      - SpotifySingleSearchResponse
      - SpotifyMultiSearchResponse

commit 16c969ca9516a6d6b1973baa77f90def11c2c974
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Dec 12 12:48:44 2023 +0900

    :sparkles: Song Entity 및 Repository 생성

    - 노래 저장을 위한 로직 추가

commit d759c320cc8e5a56e6798b39b8641c40f8096a8c
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Mon Dec 11 15:46:47 2023 +0900

    :truck: NotePageRequest -> PageRequest 클래스 명 변경 및 패키지 변경

    - NotePageRequest 에서 PageRequest 로 클래스 명을 변경하고 패키지를 Common 으로 옮김

commit d9b286fd7f2584850dc97ae90d902fa75f50fcbf
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Mon Dec 11 15:45:06 2023 +0900

    :heavy_plus_sign: Spotify 의존 추가

    - 노래 검색을 위한 Spotify 의존 추가

commit ebda01837c768ad7da5f6746b70b2544b717db2e
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Dec 6 16:46:04 2023 +0900

    :white_check_mark: 노트 전체 조회 페이징 테스트

    - NotePageRequest 인자 값으로 아무 값도 안 왔을 때 기본 값으로 잘 적용되는지 확인
    - 인자 값에 맞게 노트 객체들을 잘 조회하는지 확인

commit 79dd112e31c2643997788049a06fe5f4a6a8a13e
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Dec 6 16:44:43 2023 +0900

    :sparkles: 노트 전체 조회 Pagination 적용

    1. BeanConfig
      - JPAQueryFactory 에 EntityManager 의존 추가 후 CustomRepository 구현체에서 사용

    2. NoteCustomRepository
      - Custom Repository 생성

    3. NoteRepository
      - 구현한 Custom Repository 상속

    4. NoteRepositoryImpl
      - 구현한 Custom Repository 상속
      - Querydsl 로 실제 노트 전체 조회 구현

    5. NotePageRequest
      - Pageable 의 PageRequest 구현체 대신 사용하는 Paging Request DTO
      - 검색 조건이 추가될 수도 있기 때문에 Pageable 대신 사용할 예

    6. NoteApiController, Service, NoteMultiReadResponse
      - 특이사항 없음

commit febc902d91ee1475ddce1913ac08105067031aef
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Dec 6 16:39:04 2023 +0900

    :heavy_plus_sign: Pagination 을 위한 Querydsl 의존 추가

    - Springboot 2.x 와 설정 방법 다름 (참고)

commit b9f753339edb9e3db6972e9443d7b273f1ac7a5a
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Dec 6 13:21:30 2023 +0900

    :white_check_mark: NoteServiceTest 노트 삭제 기능 테스트

    - 노트 삭제 기능 구현으로 인한 테스트 추가

commit e5fd6cf921f93012264c45a73f2713f5b174ae12
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Dec 6 13:21:00 2023 +0900

    :sparkles: 노트 삭제 기능 구현

    - 노트 삭제 기능 구현

commit a9980775e551c419104379373bab46ae9ce11e57
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Dec 6 13:06:44 2023 +0900

    :white_check_mark: NoteServiceTest 노트 수정 테스트 추가

    - 노트 수정 기능 구현으로 인해 테스트 코드 추가

commit b0cf5b5f738db7e9c701077a8ea13726d895dd6d
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Dec 6 13:05:54 2023 +0900

    :sparkles: 노트 수정 기능 구현

    - 노트 수정 시 emotion, content 모두 수정하는 걸로 클라이언트 구현 예정이라 Petch 대신 PUT 사용
    - JPA Dirty Checking 으로 수정 되도록 구현