### PR TITLE
1/9 ~ 11 작업  (Front)

### DIFF
--- a/frontend/src/components/HomePage.vue
+++ b/frontend/src/components/HomePage.vue
@@ -1,6 +1,24 @@
 <template>
   <div>
-    <p>Home Template 미구현</p>
+    <div class="body">
+      <p class="home-title">
+        <strong>노래를 담아내는 갬성 일기장</strong>
+      </p>
+      <p class="home-description">
+        음악이 감정을 표현하는 가장 아름다운 수단 중 하나입니다.
+        음악 일기는 하루의 감동과 감정을 일기로 기록하고, 그 때 들었던 노래로 감성을 더욱 풍성하게 표현할 수 있는 특별한 일기장 앱입니다.
+      </p>
+      <p class="home-description">
+        <strong>어떤 순간이든, 언제든지 소리로 기억을 남겨보세요. "음악 일기"와 함께라면 당신의 감성이 더욱 특별한 순간으로 기억될 것입니다.</strong>
+      </p>
+    </div>
+  </div>
+  <div class="menu-body" v-if="$store.state.sessionId === null">
+    <button class="menu-button">
+      <router-link to="/login" class="login-button-router-link">
+        <font-awesome-icon :icon="['fas', 'user-tie']" /> Login
+      </router-link>
+    </button>
   </div>
 </template>
 
@@ -11,5 +29,37 @@ export default {
 </script>
 
 <style scoped>
+.home-title {
+  font-size: 20px;
+  color: black;
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.home-description {
+  font-size: 14px;
+  color: gray;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.menu-body {
+  height: auto;
+  max-width: 100%;
+  background-size: cover;
+  margin: 20px;
+  text-align: center;
+}
+
+.menu-button {
+  background-color: white;
+  border: none;
+  color: white;
+}
+
+.login-button-router-link {
+  text-decoration: none;
+  color: royalblue;
+}
 
 </style>

--- a/frontend/src/components/KakaoJoin.vue
+++ b/frontend/src/components/KakaoJoin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>로그인 중 입니다.</div>
+  <div></div>
 </template>
 
 <script>
@@ -24,8 +24,8 @@ export default {
       axios.defaults.withCredentials = true;
       axios.get('http://localhost:8080/login/' + this.code)
         .then(response => {
-          console.log(response.data);
-          this.$store.commit('saveSignInUserInfo', response.data);
+          const userinfo = response.data;
+          this.$store.commit('saveSignInUserInfo', userinfo);
           this.$router.push('/');
 
         }).catch((e) => {

--- a/frontend/src/components/MainContainer.vue
+++ b/frontend/src/components/MainContainer.vue
@@ -19,6 +19,9 @@
           <img class="profile-img" :src="$store.state.profileImageUrl" alt="profile Url">
           {{ $store.state.nickname }} 님 반갑습니다 !
         </button>
+        <button class="nav-button" @click="logout">
+          로그아웃
+        </button>
       </div>
     </div>
   </header>
@@ -45,6 +48,12 @@
 <script>
 export default {
   name: "MainContainer",
+  methods: {
+    logout() {
+      localStorage.removeItem('vuex');
+      window.location.href = '/';
+    }
+  },
 }
 </script>
 

--- a/frontend/src/components/MainContainer.vue
+++ b/frontend/src/components/MainContainer.vue
@@ -30,7 +30,9 @@
     <div class="sidebar">
       <h4 class="sidebar-name">메뉴</h4>
       <button class="sidebar-button">
-        <font-awesome-icon icon="clipboard" /> - 일기 목록
+        <router-link to="/notes" class="sidebar-router-link">
+          <font-awesome-icon icon="clipboard" /> - 일기 목록
+        </router-link>
       </button>
       <button class="sidebar-button">
         <router-link to="/note/new" class="sidebar-router-link">

--- a/frontend/src/components/NoteDetail.vue
+++ b/frontend/src/components/NoteDetail.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="body">
+    <p class="note-description">{{ `작성 일자 [${note.createAt}]` }}</p>
+    <p class="note-description">{{ `수정 일자 [${note.modifiedAt}]` }}</p>
+    <p class="note-description">{{ `이날의 감정 [${note.emotion}]` }}</p>
+    <p class="note-content">일기 내용</p>
+    <p class="note-content-font"><strong>{{ note.content }}</strong></p>
+
+    <div class="body">
+      <p class="note-content">들었던 노래</p>
+      <div class="song">
+        <div class="song-image" :style="{ backgroundImage: `url(${note.songSavedInNoteResponse?.imageUrl})` }"></div>
+        <div class="song-description">
+          <p>가수</p>
+          <p>{{ note.songSavedInNoteResponse?.artistName }}</p>
+        </div>
+        <div class="song-description">
+          <p>제목</p>
+          <p>{{ note.songSavedInNoteResponse?.title }}</p>
+        </div>
+        <div class="song-description">
+          <p>앨범</p>
+          <p>{{ note.songSavedInNoteResponse?.albumName }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</template>
+
+<script>
+import axios from 'axios';
+
+export default {
+  name: "NoteDetail",
+  data() {
+    return {
+      note: {},
+    }
+  },
+
+  created() {
+    const noteId = this.$route.params.noteId;
+    this.readNote(noteId);
+  },
+
+  methods: {
+    readNote(noteId) {
+      axios.defaults.withCredentials = true;
+      axios.get(`http://localhost:8080/api/notes/${noteId}`)
+      .then(response => {
+        console.log(response.data);
+        this.note = response.data;
+      });
+    }
+  }
+}
+</script>
+
+<style>
+.body {
+  height: auto;
+  max-width: 100%;
+  background-position: center;
+  background-size: cover;
+  margin: 20px;
+}
+
+.note-description {
+  font-size: 14px;
+  color: grey;
+  text-align: right;
+  margin-bottom: 10px;
+}
+
+.note-content {
+  font-size: 14px;
+  color: grey;
+  margin-top: 50px;
+  margin-bottom: 10px;
+}
+
+.note-content-font {
+  font-family: "Shree Devanagari 714", serif;
+  font-size: 14px;
+}
+
+.song {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px;
+  box-shadow: 0 0 1px rgba(0,0,0,0.15), 0 15px 12px rgba(0,0,0,0.15);
+}
+
+.song-image {
+  width: 100px;
+  height: 100px;
+  margin-bottom: 0;
+  background-size: 100%;
+  border-radius: 10%;
+  float: left;
+}
+
+.song-description {
+  font-size: 14px;
+  color: grey;
+  text-align: center;
+  margin-bottom: 0;
+}
+
+</style>

--- a/frontend/src/components/NoteDetail.vue
+++ b/frontend/src/components/NoteDetail.vue
@@ -52,10 +52,19 @@ export default {
         console.log(response.data);
         this.note = response.data;
       }).catch(error => {
-        const errorMessage = error.response.data.message;
-        alert(errorMessage);
-        this.$router.push("/")
-      });
+        const errorStatus = error.response.status;
+
+        if (errorStatus === 401) {
+          localStorage.removeItem('vuex');
+          alert('로그인이 필요합니다.');
+          window.location.href = '/';
+
+        } else if (errorStatus === 400) {
+          const errorMessage = error.response.data.message;
+          alert(errorMessage);
+          this.$router.push('/');
+        }
+      })
     }
   }
 }
@@ -94,7 +103,7 @@ export default {
   justify-content: space-between;
   align-items: center;
   padding: 12px;
-  box-shadow: 0 0 1px rgba(0,0,0,0.15), 0 15px 12px rgba(0,0,0,0.15);
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0.15), 0 15px 12px rgba(0, 0, 0, 0.15);
 }
 
 .song-image {

--- a/frontend/src/components/NoteDetail.vue
+++ b/frontend/src/components/NoteDetail.vue
@@ -51,6 +51,10 @@ export default {
       .then(response => {
         console.log(response.data);
         this.note = response.data;
+      }).catch(error => {
+        const errorMessage = error.response.data.message;
+        alert(errorMessage);
+        this.$router.push("/")
       });
     }
   }

--- a/frontend/src/components/NoteList.vue
+++ b/frontend/src/components/NoteList.vue
@@ -1,0 +1,172 @@
+<template>
+  <div class="body" v-for="(note, noteId) in notes" :key="noteId">
+    <div class="card">
+      <div class="card-body" @click="readNote(noteId + 1)">
+        <h5 class="card-header-description">{{ `작성일 ${note.createAt}` }}</h5>
+        <h5 class="card-header-description">{{ `수정일 ${note.modifiedAt}` }}</h5>
+        <div class="card-button-box">
+          <button class="card-button" style="margin: 5px" @click="updateNote($event)"> <!-- 이벤트 버블링 방지 -->
+            <font-awesome-icon icon="pen-to-square" /> 수정
+          </button>
+          <button class="card-button" style="margin: 5px" @click="deleteNote($event)">
+            <font-awesome-icon icon="trash-can" /> 삭제
+          </button>
+        </div>
+        <p class="card-text">{{ truncateNoteContent(note.content) }}</p>
+      </div>
+    </div>
+  </div>
+  <div class="pagination-body">
+    <button class="pagination-button" @click="readPrevPage">
+      <font-awesome-icon icon="fa-solid fa-arrow-left" /> 이전 페이지
+    </button>
+    <button class="pagination-button" @click="readNextPage">
+      다음 페이지 <font-awesome-icon icon="fa-solid fa-arrow-right" />
+    </button>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+
+export default {
+  name: "NoteList",
+  data() {
+    return {
+      notes: [],
+      currentPage: 1,
+      defaultPageSize: 5,
+      next: false,
+    }
+  },
+
+  created() {
+    this.readNotes();
+  },
+
+  methods: {
+    readNotes(next) {
+      let page = this.currentPage;
+      if (next === true) {
+        page += 1;
+      }
+
+      axios.defaults.withCredentials = true;
+      axios.get('http://localhost:8080/api/notes', {
+        params: {
+          page: page,
+          size: this.defaultPageSize,
+        }
+      })
+      .then(response => {
+        if (response.data.notes.length === 0) {
+          alert('페이지가 존재하지 않습니다.');
+        } else {
+          this.notes = response.data.notes;
+        }
+
+      }).catch(error => {
+        const errorStatus = error.response.status;
+
+        if (errorStatus === 401) {
+          localStorage.removeItem('vuex');
+          alert('로그인이 필요합니다.');
+          window.location.href = '/';
+        }
+      })
+    },
+
+    readNextPage() {
+      this.next = true;
+      this.readNotes(this.next);
+    },
+
+    readPrevPage() {
+      let page = this.currentPage;
+      page -= 1;
+
+      if (page >= 0) {
+        this.readNotes();
+      }
+    },
+
+    truncateNoteContent(noteContent) {
+      if (noteContent.length > 50) {
+        return noteContent.substring(0, 50) + '...';
+      }
+
+      return noteContent;
+    },
+
+    readNote(noteId) {
+      this.$router.push(`/note/${noteId}`);
+    },
+
+    // 구현 예정
+    updateNote(event) {
+      event.stopPropagation();
+      console.log('call update note');
+    },
+
+    // 구현 예정
+    deleteNote(event) {
+      event.stopPropagation();
+      console.log('call delete note');
+    },
+  },
+}
+</script>
+
+<style scoped>
+.body {
+  height: auto;
+  max-width: 100%;
+  background-position: center;
+  background-size: cover;
+  margin: 20px;
+}
+
+.card-header-description {
+  font-size: 14px;
+  color: grey;
+  text-align: right;
+  margin-bottom: 10px;
+}
+
+.card-button-box {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.card-button {
+  background-color: royalblue;
+  color: white;
+  border: black;
+  border-radius: 4px;
+  cursor: pointer;
+  height: 25px;
+  width: 10%;
+  text-align: center;
+}
+
+.card-button:hover {
+  background-color: #ef4a4a;
+}
+
+.pagination-body {
+  display: flex;
+  justify-content: center;
+}
+
+.pagination-button {
+  background-color: royalblue;
+  color: white;
+  border: none;
+  margin: 5px;
+  border-radius: 4px;
+}
+
+.pagination-button:hover {
+  background-color: #ef4a4a;
+}
+</style>

--- a/frontend/src/components/SaveNote.vue
+++ b/frontend/src/components/SaveNote.vue
@@ -43,7 +43,6 @@ export default {
 
         if (errorStatus === 401) {
           localStorage.removeItem('vuex');
-          document.cookie = 'JSESSIONID=; expired=Thu, 01 Jan 1970 00:00:01 UTC; path=/;'
           alert('로그인이 필요합니다.');
           window.location.href = '/';
 

--- a/frontend/src/components/SaveNote.vue
+++ b/frontend/src/components/SaveNote.vue
@@ -44,7 +44,7 @@ export default {
         if (errorStatus === 401) {
           localStorage.removeItem('vuex');
           document.cookie = 'JSESSIONID=; expired=Thu, 01 Jan 1970 00:00:01 UTC; path=/;'
-          alert('세션이 만료되어 로그인이 필요합니다.');
+          alert('로그인이 필요합니다.');
           this.$router.push('/login');
 
         } else if (errorStatus === 400) {

--- a/frontend/src/components/SaveNote.vue
+++ b/frontend/src/components/SaveNote.vue
@@ -39,11 +39,27 @@ export default {
         this.$router.push(`/note/${noteId}`);
 
       }).catch((error) => {
-        if (error.response.status === 401) {
+        const errorStatus = error.response.status;
+
+        if (errorStatus === 401) {
           localStorage.removeItem('vuex');
           document.cookie = 'JSESSIONID=; expired=Thu, 01 Jan 1970 00:00:01 UTC; path=/;'
           alert('세션이 만료되어 로그인이 필요합니다.');
-          this.$router.push('/');
+          this.$router.push('/login');
+
+        } else if (errorStatus === 400) {
+          const errorMessages = [];
+          const errors = error.response.data.validation;
+
+          for (const errorKey in errors) {
+            if (errorKey !== undefined) {
+              errorMessages.push(errors[`${errorKey}`]);
+            }
+          }
+
+          for (let i = 0; i < errorMessages.length; i++) {
+            alert(errorMessages[i])
+          }
         }
       })
     },

--- a/frontend/src/components/SaveNote.vue
+++ b/frontend/src/components/SaveNote.vue
@@ -35,10 +35,16 @@ export default {
       axios.defaults.withCredentials = true;
       axios.post('http://localhost:8080/api/notes', payload)
       .then(response => {
-        console.log(response.status);
-        console.log(response.data);
+        const noteId = response.data;
+        this.$router.push(`/note/${noteId}`);
+
       }).catch((error) => {
-        console.log(`exception message : ${error}`);
+        if (error.response.status === 401) {
+          localStorage.removeItem('vuex');
+          document.cookie = 'JSESSIONID=; expired=Thu, 01 Jan 1970 00:00:01 UTC; path=/;'
+          alert('세션이 만료되어 로그인이 필요합니다.');
+          this.$router.push('/');
+        }
       })
     },
 

--- a/frontend/src/components/SaveNote.vue
+++ b/frontend/src/components/SaveNote.vue
@@ -45,7 +45,7 @@ export default {
           localStorage.removeItem('vuex');
           document.cookie = 'JSESSIONID=; expired=Thu, 01 Jan 1970 00:00:01 UTC; path=/;'
           alert('로그인이 필요합니다.');
-          this.$router.push('/login');
+          window.location.href = '/';
 
         } else if (errorStatus === 400) {
           const errorMessages = [];

--- a/frontend/src/json/router.js
+++ b/frontend/src/json/router.js
@@ -1,10 +1,10 @@
 import {createRouter, createWebHistory} from "vue-router";
-import store from "./store"
 import UserLogin from "@/components/UserLogin";
 import KakaoJoin from "@/components/KakaoJoin";
 import HomePage from "@/components/HomePage";
 import SaveNote from "@/components/SaveNote";
 import NoteDetail from "@/components/NoteDetail";
+import axios from 'axios';
 
 const routes = [
   {
@@ -23,32 +23,39 @@ const routes = [
   {
     path: "/note/:noteId",
     component: NoteDetail,
-    beforeEnter: (to, from, next) => {
-      if (store.state.sessionId === null) {
-        next('/login');
-        alert('로그인이 필요합니다.');
-      } else {
-        next();
-      }
-    }
   },
   {
     path: '/note/new',
     component: SaveNote,
-    beforeEnter: (to, from, next) => {
-      if (store.state.sessionId === null) {
-        next('/login');
-        alert('로그인이 필요합니다.');
-      } else {
-        next();
-      }
-    }
   }
 ];
 
 const router = createRouter({
   history: createWebHistory(),
   routes,
+});
+
+router.beforeEach((to, from, next) => {
+  if (to.path === '/' || to.path === '/login' || to.path === '/oauth/kakao') {
+    next();
+  } else {
+    // 홈, login, 카카오 OAuth 경로 제외 모든 라우터 이동 시 서버 상태 및 vuex 확인
+    axios.get('http://localhost:8080/check-server-state')
+    .then(response => {
+      console.log(response.data);
+      if (localStorage.getItem('vuex') === null) {
+        alert('로그인이 필요합니다.');
+        window.location.href = '/';
+      } else {
+        next();
+      }
+    }).catch(error => {
+      console.log(error);
+      localStorage.removeItem('vuex');
+      alert('로그인이 필요합니다.');
+      window.location.href = '/';
+    });
+  }
 });
 
 export default router;

--- a/frontend/src/json/router.js
+++ b/frontend/src/json/router.js
@@ -23,6 +23,14 @@ const routes = [
   {
     path: "/note/:noteId",
     component: NoteDetail,
+    beforeEnter: (to, from, next) => {
+      if (store.state.sessionId === null) {
+        next('/login');
+        alert('세션이 만료되어 로그인이 필요합니다.');
+      } else {
+        next();
+      }
+    }
   },
   {
     path: '/note/new',
@@ -30,6 +38,7 @@ const routes = [
     beforeEnter: (to, from, next) => {
       if (store.state.sessionId === null) {
         next('/login');
+        alert('세션이 만료되어 로그인이 필요합니다.');
       } else {
         next();
       }

--- a/frontend/src/json/router.js
+++ b/frontend/src/json/router.js
@@ -4,6 +4,7 @@ import UserLogin from "@/components/UserLogin";
 import KakaoJoin from "@/components/KakaoJoin";
 import HomePage from "@/components/HomePage";
 import SaveNote from "@/components/SaveNote";
+import NoteDetail from "@/components/NoteDetail";
 
 const routes = [
   {
@@ -18,6 +19,10 @@ const routes = [
     // kakao redirect uri (인가 코드 받는 즉시 컴포넌트 생성)
     path: '/oauth/kakao',
     component: KakaoJoin,
+  },
+  {
+    path: "/note/:noteId",
+    component: NoteDetail,
   },
   {
     path: '/note/new',

--- a/frontend/src/json/router.js
+++ b/frontend/src/json/router.js
@@ -5,6 +5,7 @@ import HomePage from "@/components/HomePage";
 import SaveNote from "@/components/SaveNote";
 import NoteDetail from "@/components/NoteDetail";
 import axios from 'axios';
+import NoteList from "@/components/NoteList";
 
 const routes = [
   {
@@ -19,6 +20,10 @@ const routes = [
     // kakao redirect uri (인가 코드 받는 즉시 컴포넌트 생성)
     path: '/oauth/kakao',
     component: KakaoJoin,
+  },
+  {
+    path: "/notes",
+    component: NoteList,
   },
   {
     path: "/note/:noteId",

--- a/frontend/src/json/router.js
+++ b/frontend/src/json/router.js
@@ -26,7 +26,7 @@ const routes = [
     beforeEnter: (to, from, next) => {
       if (store.state.sessionId === null) {
         next('/login');
-        alert('세션이 만료되어 로그인이 필요합니다.');
+        alert('로그인이 필요합니다.');
       } else {
         next();
       }
@@ -38,7 +38,7 @@ const routes = [
     beforeEnter: (to, from, next) => {
       if (store.state.sessionId === null) {
         next('/login');
-        alert('세션이 만료되어 로그인이 필요합니다.');
+        alert('로그인이 필요합니다.');
       } else {
         next();
       }

--- a/frontend/src/json/store.js
+++ b/frontend/src/json/store.js
@@ -11,11 +11,11 @@ const store = createStore({
   },
 
   mutations: {
-    saveSignInUserInfo(state, data) {
-      state.sessionId = data.jsessionId;
-      state.nickname = data.nickname;
-      state.profileImageUrl = data.profileImageUrl;
-    }
+    saveSignInUserInfo(state, userinfo) {
+      state.sessionId = userinfo.sessionId;
+      state.nickname = userinfo.nickname;
+      state.profileImageUrl = userinfo.profileImageUrl;
+    },
   },
 
   actions: {

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -2,9 +2,4 @@ const {defineConfig} = require('@vue/cli-service')
 
 module.exports = defineConfig({
   transpileDependencies: true,
-  proxy: {
-    '/': {
-      ws: false,
-    }
-  }
 })


### PR DESCRIPTION
commit 24c3adde7ea4e36750067c09939528d255003cf1 (HEAD -> front-develop, origin/front-develop)
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Jan 11 16:29:38 2024 +0900

    :sparkles: 전체 노트 조회 폼 구현

    1. NoteList.vue
      - readNotes()
        - 최초 created() 호출 시 전체 노트의 1 페이지 호출
        - next 값이 true 라면 다음 페이지를 조회 단, Array 가 비었다면 알람창을 띄우고 페이지 이동하지 않도록 구현
        - 지역변수 let page 를 사용한 이유는 this.currentPage 를 직접 조작하면 알람창 로직 이후 다시 기본 값 1로 초기화 시켜야하기 때문에 귀찮아서 ..

      - readNextPage()
        - 다음 페이지를 호출하고 싶다는 next 값만 true 로 바꾸고 readNotes() 에 매개변수로 전달하며 호출하도록 작성

      - readPrevPage()
        - page 가 양수 및 0보다 클 때만 이전 페이지 호출하도록 작성

      - truncateNoteContent()
        - 노트의 내용이 50자를 초과할 때 '...' 붙여서 중략할 수 있도록 작성

      - readNote()
        - NoteDetail.vue 로 이동할 수 있도록 작성

    2. MainContainer.vue
      - NoteList.vue 로 이동할 수 있는 라우터 링크 추가

    3. router.js
      - NoteList.vue 컴포넌트 라우터에 추가

commit f00f9892286a40c5d9431272995f603b87d125b6
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Jan 11 13:33:01 2024 +0900

    :recycle: noteDetail.vue 수정

    - readNote()
      - 401 예외를 받았을 때 catch() 문으로 처리하도록 로직 추가

commit 1a4cb94c13ab31441529ccab2e413be4dff4753c
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Jan 10 16:56:00 2024 +0900

    :recycle: SaveNote.vue 수정

    - saveNote()
      - 쿠키의 Http-only 옵션 활성화로 인해 클라이언트에서 조작할 수 없지만, 재로그인 시 서버에 세션이 남아있다면 원래 사용하던 세션 정보를 쿠키에 담아 응답하고, 서버의 세션이 만료되었다면 새로 생성해 응답하므로 굳이 쿠키를 클라이언트에서 조작할 필요가 없다.

commit fe13cc655ce071631fa4767d27c87e9cc1ba751d
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Jan 10 16:51:32 2024 +0900

    :sparkles: MainContainer.vue 기능 추가

    - logout()
      - 로그아웃 버튼 클릭 시 LocalStorage 의 Vuex 값을 삭제하고 홈페이지로 새로고침 이동

commit 8506dced6fbffab04ea1f4f1b6bbd83e4e5510ab
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Jan 10 16:22:40 2024 +0900

    :recycle: SaveNote.vue 수정

    - saveNote()
      - 로그인 폼('/login') 으로 router 이동이 아닌 새로고침 방식으로 이동하도록 변경
      - 새로고침으로 이동해야 LocalStorage 값을 갱신해서 Header 의 정보를 다시 렌더링하기 때문에 router 이동 대신 새로고침 방식으로 변경

commit 95e39a3eec40047c6c7269e3c518d746ef63575d
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Jan 10 16:20:16 2024 +0900

    :recycle: Component Router Guard 에서 Global Router Guard 로 변경

    - 홈('/'), 로그인 폼('/login'), 카카오 OAuth('/oauth/kakao') 경로를 제외하고 라우터 링크 이동 감지 시 서버가 켜져있는지 확인하고 LocalStorage 의 Vuex 값이 null 인지 확인
    - 서버가 꺼지거나 켜졌지만 Vuex 값이 null 인 경우 로그인 창으로 이동(새로고침)

commit 9c5c5f60370d54c47255b8a52a52b630147b641d
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Jan 9 21:28:24 2024 +0900

    :recycle: 알람창 메세지 변경

    - 세션 만료 또는 비회원인 경우 로그인이 필요합니다. 로 알람 메세지 변경

commit f1addb257e7449d405c6edfaa4f177ed54b32dd3
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Jan 9 21:27:48 2024 +0900

    :sparkles: 홈페이지 폼 구현

    - 홈페이지 폼 구현

commit 27fd4ed55d51dea5f4dc34765bd4dffaa0d3ca5c
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Jan 9 20:34:24 2024 +0900

    :recycle: SaveNote.vue 수정

    - saveNote()
      - 400 Bad Request 를 응답 코드로 받았을 때 서버에서 응답한 에러 메세지를 알람 창으로 띄울 수 있도록 로직 추가

commit 2fe6917e2d22f263fe24e99adbecd90390828ce9
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Jan 9 20:31:28 2024 +0900

    :sparkles: NoteDetail Router Guard 추가

    - session 만료 후 노트 단일 조회 시 로그인 페이지로 이동하도록 라우터 가드 추가

commit 1edc674c4f06a5b90169aee4c97571edc27a5977
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Jan 9 20:30:20 2024 +0900

    :recycle: NoteDetail.vue 수정

    - readNote()
      - 존재하지 않는 노트를 조회할 시 catch() 를 통해 서버에서 응답한 에러 메세지를 알람 창으로 띄울 수 있도록 로직 추가

commit 914b1f8d61218c4b0714fa3cdcf09a5016b09a84
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Jan 9 16:03:56 2024 +0900

    :sparkles: 노트 단일 조회 폼 구현 및 라우터 설정

    - NoteDetail.vue
      - created()
        - 라이프 사이클 훅 created() 를 활용해 URI 의 noteId 를 추출해 readNote() 호출하도록 구현
      - readNote()
        - 서버에서 해당 ID 를 가진 단일 노트 조회 후 데이터 바인딩 할 수 있도록 구현

    - router.js
      - noteId 를 추출할 수 있도록 path 설정

commit bd4beff8e00c226d984b9a7ca89f36590643c04e
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Jan 9 16:00:29 2024 +0900

    :recycle: 로그인 관련 로직 수정

    - KakaoJoin.vue
      - sendCode()
        - response.data 값을 userinfo 변수에 할당한 뒤 사용하도록 수정

    - store.js
      - mutations 의 saveSignInUserInfo() 의 매개변수를 data 가 아닌 userinfo 로 명시해 사용하도록 수정

commit 2cb5a5c54f4cfc9ab472e87fcb2bc82eda8f3a73
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Jan 9 15:58:24 2024 +0900

    :recycle: 노트 저장 수정

    - SaveNote.vue
      - saveNote()
        - 노트 작성 시 곧바로 해당 노트로 이동하도록 수정
        - 세션 만료 시 vuex 값 제거 및 쿠키 (JSESSIONID) 을 제거 후 홈페이지로 이동하도록 로직 추가