### PR TITLE
1/16 ~ 17 작업 (backend)

### DIFF
--- a/backend/src/main/generated/com/emotionmusicnote/note/domain/QNote.java
+++ b/backend/src/main/generated/com/emotionmusicnote/note/domain/QNote.java
@@ -36,6 +36,8 @@ public class QNote extends EntityPathBase<Note> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> modifiedDate = _super.modifiedDate;
 
+    public final ListPath<com.emotionmusicnote.song.domain.Song, com.emotionmusicnote.song.domain.QSong> songs = this.<com.emotionmusicnote.song.domain.Song, com.emotionmusicnote.song.domain.QSong>createList("songs", com.emotionmusicnote.song.domain.Song.class, com.emotionmusicnote.song.domain.QSong.class, PathInits.DIRECT2);
+
     public final com.emotionmusicnote.user.domain.QUser user;
 
     public QNote(String variable) {

--- a/backend/src/main/java/com/emotionmusicnote/note/controller/response/NoteSingleReadResponse.java
+++ b/backend/src/main/java/com/emotionmusicnote/note/controller/response/NoteSingleReadResponse.java
@@ -2,6 +2,7 @@ package com.emotionmusicnote.note.controller.response;
 
 import com.emotionmusicnote.song.controller.response.SongSavedInNoteResponse;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,18 +15,18 @@ public class NoteSingleReadResponse {
   private final LocalDateTime createAt;
   private final LocalDateTime modifiedAt;
   private final NoteWriterResponse noteWriterResponse;
-  private final SongSavedInNoteResponse songSavedInNoteResponse;
+  private final List<SongSavedInNoteResponse> songSavedInNoteResponses;
 
   @Builder
   public NoteSingleReadResponse(Long id, String emotion, String content, LocalDateTime createAt,
       LocalDateTime modifiedAt, NoteWriterResponse noteWriterResponse,
-      SongSavedInNoteResponse songSavedInNoteResponse) {
+      List<SongSavedInNoteResponse> songSavedInNoteResponses) {
     this.id = id;
     this.emotion = emotion;
     this.content = content;
     this.createAt = createAt;
     this.modifiedAt = modifiedAt;
     this.noteWriterResponse = noteWriterResponse;
-    this.songSavedInNoteResponse = songSavedInNoteResponse;
+    this.songSavedInNoteResponses = songSavedInNoteResponses;
   }
 }

--- a/backend/src/main/java/com/emotionmusicnote/note/domain/Note.java
+++ b/backend/src/main/java/com/emotionmusicnote/note/domain/Note.java
@@ -1,7 +1,9 @@
 package com.emotionmusicnote.note.domain;
 
 import com.emotionmusicnote.common.BaseTime;
+import com.emotionmusicnote.song.domain.Song;
 import com.emotionmusicnote.user.domain.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,6 +13,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,6 +40,9 @@ public class Note extends BaseTime {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   private User user;
+
+  @OneToMany(mappedBy = "note", cascade = CascadeType.REMOVE)
+  List<Song> songs = new ArrayList<>();
 
   @Builder
   public Note(String emotion, String content) {

--- a/backend/src/main/java/com/emotionmusicnote/note/service/NoteService.java
+++ b/backend/src/main/java/com/emotionmusicnote/note/service/NoteService.java
@@ -64,11 +64,7 @@ public class NoteService {
     Note findNote = noteRepository.findById(noteId, loginUserId)
         .orElseThrow(NotFoundNoteException::new);
 
-    Song findSong = songRepository.findByNoteId(noteId)
-        .orElseThrow(NotFoundNoteException::new);
-
     noteRepository.delete(findNote);
-    songRepository.delete(findSong);
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
commit 68542e3019f8b455387dfeadd151c05e001a0e7b (HEAD -> back-develop, origin/back-develop)
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Jan 17 17:18:54 2024 +0900

    :recycle: 노트 <-> 노래 양방향 연관관계로 인한 NoteService read() 수정

    - 노트에 List<Song> songs 가 추가됨에 따라 기존에 SongRepository 로 노트에 저장된 노래를 찾는 createSongSavedInNoteResponse() 를 삭제하고 노트에서 노래를 찾을 수 있도록 변경
    - Response DTO 필드 변경

commit 6d09d0ec05292aa2fd46ec1c34031307cf7852c0
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Jan 17 17:07:09 2024 +0900

    :recycle: Note 에서 Song 의 연관관계 추가 및 NoteService 의 delete() 수정

    - 기존의 Song -> Note 단방향 연관관계에서 Song <-> Note 양방향 연관관계로 수정
    - 여러 상황에 관한 테스트를 진행하면서 버그를 발견했기에 수정
      - 현재 노트 저장 API 플로우 상 저장 API 를 호출한 뒤에 노래 저장 API 를 호출하기 때문에, 중간에 어떠한 문제로 노래가 제대로 저장되지 않는다면 노트 삭제 시 노트 ID 를 통해 노래를 찾는 로직에서 400 예외를 뱉어내게 됨.
      - 하지만 현재 단방향 관계로는 노트에서 노래를 찾을 수 있는 방법이 없음.
       - 따라서 노트 삭제 시 해당 노트에 연관된 노래를 찾지 않고 삭제하도록 로직을 수정해야 함. 이를 위해 양방향 연관관계를 맺고 Cascade remove 설정을 달아주는 것이 옳아보임.
       - 노트 저장 / 노래 저장 API 는 서로 다르기 때문에 양방향 연관관계 편의 메서드는 필요없다고 판단.