### PR TITLE
2/8 작업 (Front)

### DIFF
--- a/frontend/src/components/NoteDetail.vue
+++ b/frontend/src/components/NoteDetail.vue
@@ -57,14 +57,8 @@ export default {
       }).catch(error => {
         const errorStatus = error.response.data.code;
 
-        // Interceptor preHandler()
-        if (errorStatus === 401) {
-          localStorage.removeItem('vuex');
-          alert(error.response.data.message);
-          window.location.href = '/';
-
         // NotFoundNoteException
-        } else if (errorStatus === 404) {
+        if (errorStatus === 404) {
           const errorMessage = error.response.data.message;
           alert(errorMessage);
           this.$router.push('/');

--- a/frontend/src/components/NoteList.vue
+++ b/frontend/src/components/NoteList.vue
@@ -80,7 +80,7 @@ export default {
   },
 
   methods: {
-    "readData"() {
+    readData() {
       const params = this.loadParams();
       const uri = this.loadUri();
       console.log(`현재 페이지: ${this.currentPage}`);
@@ -103,6 +103,7 @@ export default {
       .catch(error => {
         const errorStatus = error.response.data.code;
 
+        // Interceptor preHandler()
         if (errorStatus === 401) {
           localStorage.removeItem('vuex');
           alert(error.response.data.message);
@@ -111,7 +112,7 @@ export default {
       })
     },
 
-    "loadParams"() {
+    loadParams() {
       return {
         "page": this.currentPage,
         "size": this.defaultPageSize,
@@ -120,46 +121,46 @@ export default {
       };
     },
 
-    "loadUri"() {
+    loadUri() {
       // 날짜 필터링을 적용하고 조회했을때 /api/notes/date 엔드 포인트 사용
       return this.dateFilterSelecting ? '/api/notes/date' : '/api/notes';
     },
 
-    "fetchData"(params, uri) {
+    fetchData(params, uri) {
       axios.defaults.withCredentials = true;
       const apiServer = process.env.VUE_APP_API_SERVER;
 
       return axios.get(`${apiServer}${uri}`, {params});
     },
 
-    "filterSwitch"() {
+    filterSwitch() {
       this.dateFilterSwitch = !this.dateFilterSwitch;
     },
 
     // End-Point 변경을 위해 dateFilterSelecting = true;
     // 어떤 페이지에서든 날짜 필터링 이후 조회 시 1 페이지부터 조회하도록 this.currentPage = 1;
-    "dateFilterSelect"() {
+    dateFilterSelect() {
       this.dateFilterSelecting = true;
       this.currentPage = 1;
       this.readData();
     },
 
-    "readNextPage"() {
+    readNextPage() {
       this.currentPage += 1;
       this.readData();
     },
 
-    "readPrevPage"() {
+    readPrevPage() {
       this.currentPage -= 1;
       this.readData();
     },
 
-    "clickUpdate"(event, noteId) {
+    clickUpdate(event, noteId) {
       event.stopPropagation();
       this.$router.push(`/note/update/${noteId}`);
     },
 
-    "clickDelete"(event, noteId) {
+    clickDelete(event, noteId) {
       event.stopPropagation();
       const result = window.confirm('정말 삭제하시겠습니까 ?');
 
@@ -173,14 +174,13 @@ export default {
 
         }).catch(error => {
           const errorStatus = error.response.data.code;
-
           // Interceptor preHandler()
           if (errorStatus === 401) {
             localStorage.removeItem('vuex');
             alert(error.response.data.message);
             window.location.href = '/';
 
-            // NotFoundNoteException
+          // NotFoundNoteException
           } else if (errorStatus === 400) {
             const errorMessage = error.response.data.message;
             alert(errorMessage);
@@ -190,11 +190,11 @@ export default {
       }
     },
 
-    "readNote"(noteId) {
+    readNote(noteId) {
       this.$router.push(`/note/detail/${noteId}`);
     },
 
-    "truncateNoteContent"(noteContent) {
+    truncateNoteContent(noteContent) {
       if (noteContent.length > 50) {
         return noteContent.substring(0, 50) + '...';
       }

--- a/frontend/src/components/NoteSave.vue
+++ b/frontend/src/components/NoteSave.vue
@@ -36,7 +36,7 @@ export default {
         this.$router.push(`/song/save/search`);
 
       }).catch((error) => {
-        const errorStatus = error.response.data.error;
+        const errorStatus = error.response.data.code;
 
         // Interceptor preHandler()
         if (errorStatus === 401) {

--- a/frontend/src/components/NoteUpdate.vue
+++ b/frontend/src/components/NoteUpdate.vue
@@ -17,6 +17,7 @@ import axios from 'axios';
 
 export default {
   name: "NoteUpdate",
+
   data() {
     return {
       noteId: 0,
@@ -39,14 +40,8 @@ export default {
     }).catch(error => {
       const errorStatus = error.response.data.code;
 
-      // Interceptor preHandler()
-      if (errorStatus === 401) {
-        localStorage.removeItem('vuex');
-        alert(error.response.data.message);
-        window.location.href = '/';
-
       // NotFoundNoteException
-      } else if (errorStatus === 404) {
+      if (errorStatus === 404) {
         const errorMessages = error.response.data.message;
         alert(errorMessages);
         this.$router.push('/');
@@ -65,7 +60,6 @@ export default {
         this.$router.push(`/note/detail/${this.noteId}`);
 
       }).catch(error => {
-        console.log(error.response.data);
         const errorStatus = error.response.data.code;
 
         // Interceptor preHandler()


### PR DESCRIPTION
commit 57e0c105b30ddb5ccd2c7242335744a146acf020 (HEAD -> front-develop, origin/front-develop)
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Feb 8 15:45:57 2024 +0900

    :recycle: Vue Component 세션 검증부분 전체 확인

    - 컴포넌트에 접근하는 것은 글로벌 라우터 가드에서 세션 검증이 이뤄지지만, 이미 컴포넌트에 접근한 상태에서 세션이 만료되거나 삭제됐다면 해당 컴포넌트에서 사용할 수 있는 기능 API 호출 시 세션 검증이 필요함.

    - 따라서 불필요하게 컴포넌트에서 이중으로 세션 401 예외를 캐치하는 부분을 삭제, 컴포넌트에서 호출 가능한 기능 API 에 대해선 세션 401 예외를 다시 한 번 캐치할 수 있도록 수정

commit 7a768a2c6c460a82845c3ad4bd85940e3ff83a58
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Feb 8 15:41:29 2024 +0900

    :recycle: Router.js Global Router Guard 수정

    - Vuex 검증 부분 삭제 (세션 검증과 헷갈림..)
      - Vuex 데이터가 없다면 Header 에서 닉네임, 프로필 사진이 안나오는데 이거랑 세션과는 관계없으니 딱히 검증하지 않도록 수정

    - 서버와 통신이 불가능한 상태 즉, /api/check-server-state 에 대한 에러는 모두 /error 페이지로 이동하도록 수정